### PR TITLE
Issue: (#16) 커플 기념일 설정, 입대일 설정

### DIFF
--- a/src/main/kotlin/gomushin/backend/couple/domain/entity/Couple.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/entity/Couple.kt
@@ -26,8 +26,6 @@ class Couple(
     @Column(name = "military_end_date")
     var militaryEndDate: LocalDate? = null,
 
-    @Column(name = "advancement_date")
-    var advancementDate: LocalDate? = null,
 ): BaseEntity() {
     companion object {
         fun of(
@@ -39,5 +37,16 @@ class Couple(
                 inviteeId = inviteeId,
             )
         }
+    }
+
+    fun updateAnniversary(
+        relationshipStartDate: LocalDate?,
+        militaryStartDate: LocalDate?,
+        militaryEndDate: LocalDate?,
+    ): Couple {
+        this.relationshipStartDate = relationshipStartDate ?: this.relationshipStartDate
+        this.militaryStartDate = militaryStartDate ?: this.militaryStartDate
+        this.militaryEndDate = militaryEndDate ?: this.militaryEndDate
+        return this
     }
 }

--- a/src/main/kotlin/gomushin/backend/couple/domain/entity/Couple.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/entity/Couple.kt
@@ -26,7 +26,7 @@ class Couple(
     @Column(name = "military_end_date")
     var militaryEndDate: LocalDate? = null,
 
-): BaseEntity() {
+    ) : BaseEntity() {
     companion object {
         fun of(
             invitorId: Long,
@@ -43,10 +43,9 @@ class Couple(
         relationshipStartDate: LocalDate?,
         militaryStartDate: LocalDate?,
         militaryEndDate: LocalDate?,
-    ): Couple {
+    ) {
         this.relationshipStartDate = relationshipStartDate ?: this.relationshipStartDate
         this.militaryStartDate = militaryStartDate ?: this.militaryStartDate
         this.militaryEndDate = militaryEndDate ?: this.militaryEndDate
-        return this
     }
 }

--- a/src/main/kotlin/gomushin/backend/couple/domain/service/CoupleConnectService.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/service/CoupleConnectService.kt
@@ -2,6 +2,7 @@ package gomushin.backend.couple.domain.service
 
 import gomushin.backend.core.infrastructure.exception.BadRequestException
 import gomushin.backend.couple.domain.entity.Couple
+import gomushin.backend.couple.dto.request.CoupleAnniversaryRequest
 import gomushin.backend.member.domain.service.MemberService
 import gomushin.backend.member.util.CoupleCodeGeneratorUtil
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -69,19 +70,16 @@ class CoupleConnectService(
     @Transactional
     fun registerAnniversary(
         userId: Long,
-        coupleId: Long,
-        relationshipStartDate: LocalDate,
-        militaryStartDate: LocalDate,
-        militaryEndDate: LocalDate,
+        request: CoupleAnniversaryRequest
     ) {
-        val couple = coupleService.getById(coupleId)
+        val couple = coupleService.getById(request.coupleId)
         if (!checkUserInCouple(userId, couple)) {
             throw BadRequestException("sarangggun.couple.not-in-couple")
         }
         couple.updateAnniversary(
-            relationshipStartDate = relationshipStartDate,
-            militaryStartDate = militaryStartDate,
-            militaryEndDate = militaryEndDate,
+            relationshipStartDate = request.relationshipStartDate,
+            militaryStartDate = request.militaryStartDate,
+            militaryEndDate = request.militaryEndDate,
         )
     }
 

--- a/src/main/kotlin/gomushin/backend/couple/domain/service/CoupleService.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/service/CoupleService.kt
@@ -1,0 +1,28 @@
+package gomushin.backend.couple.domain.service
+
+import gomushin.backend.core.infrastructure.exception.BadRequestException
+import gomushin.backend.couple.domain.entity.Couple
+import gomushin.backend.couple.domain.repository.CoupleRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CoupleService(
+    private val coupleRepository: CoupleRepository
+) {
+    @Transactional(readOnly = true)
+    fun getById(id: Long): Couple {
+        return findById(id) ?: throw BadRequestException("sarangggun.couple.not-found")
+    }
+
+    @Transactional(readOnly = true)
+    fun findById(id: Long): Couple? {
+        return coupleRepository.findByIdOrNull(id)
+    }
+
+    @Transactional
+    fun save(couple: Couple): Couple {
+        return coupleRepository.save(couple)
+    }
+}

--- a/src/main/kotlin/gomushin/backend/couple/dto/request/CoupleAnniversaryRequest.kt
+++ b/src/main/kotlin/gomushin/backend/couple/dto/request/CoupleAnniversaryRequest.kt
@@ -1,0 +1,18 @@
+package gomushin.backend.couple.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+class CoupleAnniversaryRequest(
+    @Schema(description = "커플 ID", example = "1")
+    val coupleId: Long,
+
+    @Schema(description = "처음 만난 날", example = "2022-10-01")
+    val relationshipStartDate: LocalDate,
+
+    @Schema(description = "입대일", example = "2023-01-01")
+    val militaryStartDate: LocalDate,
+
+    @Schema(description = "전역일", example = "2024-10-28")
+    val militaryEndDate: LocalDate,
+)

--- a/src/main/kotlin/gomushin/backend/couple/dto/request/CoupleAnniversaryRequest.kt
+++ b/src/main/kotlin/gomushin/backend/couple/dto/request/CoupleAnniversaryRequest.kt
@@ -3,7 +3,7 @@ package gomushin.backend.couple.dto.request
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
-class CoupleAnniversaryRequest(
+data class CoupleAnniversaryRequest(
     @Schema(description = "커플 ID", example = "1")
     val coupleId: Long,
 

--- a/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
@@ -2,6 +2,7 @@ package gomushin.backend.couple.facade
 
 import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.couple.domain.service.CoupleConnectService
+import gomushin.backend.couple.dto.request.CoupleAnniversaryRequest
 import gomushin.backend.couple.dto.request.CoupleConnectRequest
 import org.springframework.stereotype.Component
 
@@ -13,9 +14,19 @@ class CoupleFacade(
     fun requestCoupleCodeGeneration(customUserDetails: CustomUserDetails) =
         coupleConnectService.generateCoupleCode(customUserDetails.getId())
 
-
     fun requestCoupleConnect(
         customUserDetails: CustomUserDetails,
         request: CoupleConnectRequest
     ) = coupleConnectService.connectCouple(customUserDetails.getId(), request.coupleCode)
+
+    fun registerAnniversary(
+        customUserDetails: CustomUserDetails,
+        request: CoupleAnniversaryRequest
+    ) = coupleConnectService.registerAnniversary(
+        customUserDetails.getId(),
+        request.coupleId,
+        request.relationshipStartDate,
+        request.militaryStartDate,
+        request.militaryEndDate
+    )
 }

--- a/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
@@ -24,9 +24,6 @@ class CoupleFacade(
         request: CoupleAnniversaryRequest
     ) = coupleConnectService.registerAnniversary(
         customUserDetails.getId(),
-        request.coupleId,
-        request.relationshipStartDate,
-        request.militaryStartDate,
-        request.militaryEndDate
+        request
     )
 }

--- a/src/main/kotlin/gomushin/backend/couple/presentation/ApiPath.kt
+++ b/src/main/kotlin/gomushin/backend/couple/presentation/ApiPath.kt
@@ -3,4 +3,5 @@ package gomushin.backend.couple.presentation
 object ApiPath {
     const val COUPLE_CODE_GENERATE = "/v1/couple/code-generate"
     const val COUPLE_CONNECT = "/v1/couple/connect"
+    const val COUPLE_ANNIVERSARY = "/v1/couple/anniversary"
 }

--- a/src/main/kotlin/gomushin/backend/couple/presentation/CoupleConnectController.kt
+++ b/src/main/kotlin/gomushin/backend/couple/presentation/CoupleConnectController.kt
@@ -8,9 +8,11 @@ import gomushin.backend.couple.dto.request.CoupleConnectRequest
 import gomushin.backend.couple.facade.CoupleFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -19,6 +21,7 @@ class CoupleConnectController(
     private val coupleFacade: CoupleFacade
 ) {
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(ApiPath.COUPLE_CODE_GENERATE)
     @Operation(
         summary = "커플 코드를 생성합니다. 커플 코드는 60분 동안 유효합니다.",
@@ -29,6 +32,7 @@ class CoupleConnectController(
     ): ApiResponse<String> =
         ApiResponse.success(coupleFacade.requestCoupleCodeGeneration(customUserDetails))
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(ApiPath.COUPLE_CONNECT)
     @Operation(
         summary = "커플 코드를 통해 남자친구(여자친구)와 연결합니다.",
@@ -42,6 +46,7 @@ class CoupleConnectController(
         return ApiResponse.success(couple)
     }
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(ApiPath.COUPLE_ANNIVERSARY)
     @Operation(
         summary = "커플 기념일(처음 만난 날, 입대일, 전역일)을 등록합니다.(이건 수정 아니고, 초기 등록)",

--- a/src/main/kotlin/gomushin/backend/couple/presentation/CoupleConnectController.kt
+++ b/src/main/kotlin/gomushin/backend/couple/presentation/CoupleConnectController.kt
@@ -2,6 +2,8 @@ package gomushin.backend.couple.presentation
 
 import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.core.common.web.response.ApiResponse
+import gomushin.backend.couple.domain.entity.Couple
+import gomushin.backend.couple.dto.request.CoupleAnniversaryRequest
 import gomushin.backend.couple.dto.request.CoupleConnectRequest
 import gomushin.backend.couple.facade.CoupleFacade
 import io.swagger.v3.oas.annotations.Operation
@@ -19,8 +21,8 @@ class CoupleConnectController(
 
     @PostMapping(ApiPath.COUPLE_CODE_GENERATE)
     @Operation(
-        summary = "커플 코드 생성",
-        description = "커플 코드를 생성합니다. 커플 코드는 60분 동안 유효합니다."
+        summary = "커플 코드를 생성합니다. 커플 코드는 60분 동안 유효합니다.",
+        description = "generateCoupleCode"
     )
     fun generateCoupleCode(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails
@@ -29,14 +31,27 @@ class CoupleConnectController(
 
     @PostMapping(ApiPath.COUPLE_CONNECT)
     @Operation(
-        summary = "커플 코드 연결",
-        description = "커플 코드를 통해 남자친구(여자친구)와 연결합니다."
+        summary = "커플 코드를 통해 남자친구(여자친구)와 연결합니다.",
+        description = "connectCouple"
     )
     fun connectCouple(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
         @RequestBody request: CoupleConnectRequest,
+    ): ApiResponse<Couple> {
+        val couple = coupleFacade.requestCoupleConnect(customUserDetails, request)
+        return ApiResponse.success(couple)
+    }
+
+    @PostMapping(ApiPath.COUPLE_ANNIVERSARY)
+    @Operation(
+        summary = "커플 기념일(처음 만난 날, 입대일, 전역일)을 등록합니다.(이건 수정 아니고, 초기 등록)",
+        description = "registerAnniversary"
+    )
+    fun registerAnniversary(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @RequestBody request: CoupleAnniversaryRequest,
     ): ApiResponse<Boolean> {
-        coupleFacade.requestCoupleConnect(customUserDetails, request)
+        coupleFacade.registerAnniversary(customUserDetails, request)
         return ApiResponse.success(true)
     }
 }

--- a/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
+++ b/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class MemberInfoService(
+class MemberService(
     private val memberRepository: MemberRepository,
 ) {
 

--- a/src/main/kotlin/gomushin/backend/member/facade/MemberInfoFacade.kt
+++ b/src/main/kotlin/gomushin/backend/member/facade/MemberInfoFacade.kt
@@ -1,16 +1,16 @@
 package gomushin.backend.member.facade
 
 import gomushin.backend.core.CustomUserDetails
-import gomushin.backend.member.domain.service.MemberInfoService
+import gomushin.backend.member.domain.service.MemberService
 import gomushin.backend.member.dto.response.MyInfoResponse
 import org.springframework.stereotype.Component
 
 @Component
 class MemberInfoFacade(
-    private val memberInfoService: MemberInfoService,
+    private val memberService: MemberService,
 ) {
     fun getMemberInfo(customUserDetails: CustomUserDetails): MyInfoResponse {
-        val member = memberInfoService.getById(customUserDetails.getId())
+        val member = memberService.getById(customUserDetails.getId())
         return MyInfoResponse.of(member)
     }
 }

--- a/src/main/kotlin/gomushin/backend/member/presentation/MemberInfoController.kt
+++ b/src/main/kotlin/gomushin/backend/member/presentation/MemberInfoController.kt
@@ -6,8 +6,10 @@ import gomushin.backend.member.facade.MemberInfoFacade
 import gomushin.backend.member.dto.response.MyInfoResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -16,6 +18,7 @@ class MemberInfoController(
     private val memberInfoFacade: MemberInfoFacade,
 ) {
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping(ApiPath.MY_INFO)
     @Operation(summary = "내 정보 조회", description = "getMyInfo")
     fun get(

--- a/src/main/kotlin/gomushin/backend/member/presentation/OnboardingController.kt
+++ b/src/main/kotlin/gomushin/backend/member/presentation/OnboardingController.kt
@@ -6,9 +6,11 @@ import gomushin.backend.member.facade.OnboardingFacade
 import gomushin.backend.member.dto.request.OnboardingRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -17,6 +19,7 @@ class OnboardingController(
     private val onboardingFacade: OnboardingFacade,
 ) {
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(ApiPath.ONBOARDING)
     @Operation(summary = "온보딩", description = "onboarding")
     fun onboarding(

--- a/src/test/kotlin/gomushin/backend/couple/domain/service/CoupleServiceTest.kt
+++ b/src/test/kotlin/gomushin/backend/couple/domain/service/CoupleServiceTest.kt
@@ -1,0 +1,85 @@
+package gomushin.backend.couple.domain.service
+
+import gomushin.backend.couple.domain.entity.Couple
+import gomushin.backend.couple.domain.repository.CoupleRepository
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+class CoupleServiceTest {
+
+    @Mock
+    private lateinit var coupleRepository: CoupleRepository
+
+    @InjectMocks
+    private lateinit var coupleService: CoupleService
+
+    @DisplayName("getById - 성공")
+    @Test
+    fun getById_success() {
+        // given
+        val coupleId = 1L
+        val couple = Couple(
+            id = coupleId,
+            invitorId = 1L,
+            inviteeId = 2L,
+        )
+
+        `when`(coupleRepository.findById(coupleId)).thenReturn(Optional.of(couple))
+
+        // when
+        val result = coupleService.getById(coupleId)
+
+        // then
+        assert(result.id == coupleId)
+        verify(coupleRepository).findById(coupleId)
+    }
+
+    @DisplayName("findById - 성공")
+    @Test
+    fun findById_success() {
+        // given
+        val coupleId = 1L
+        val couple = Couple(
+            id = coupleId,
+            invitorId = 1L,
+            inviteeId = 2L,
+        )
+
+        `when`(coupleRepository.findById(coupleId)).thenReturn(Optional.of(couple))
+
+        // when
+        val result = coupleService.findById(coupleId)
+
+        // then
+        assert(result?.id == coupleId)
+        verify(coupleRepository).findById(coupleId)
+    }
+
+    @DisplayName("save - 성공")
+    @Test
+    fun save_success() {
+        // given
+        val couple = Couple(
+            id = 1L,
+            invitorId = 1L,
+            inviteeId = 2L,
+        )
+
+        `when`(coupleRepository.save(couple)).thenReturn(couple)
+
+        // when
+        val result = coupleService.save(couple)
+
+        // then
+        assert(result.id == couple.id)
+        verify(coupleRepository).save(couple)
+    }
+}

--- a/src/test/kotlin/gomushin/backend/member/domain/service/MemberServiceTest.kt
+++ b/src/test/kotlin/gomushin/backend/member/domain/service/MemberServiceTest.kt
@@ -15,13 +15,13 @@ import java.util.*
 import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
-class MemberInfoServiceTest {
+class MemberServiceTest {
 
     @Mock
     private lateinit var memberRepository: MemberRepository
 
     @InjectMocks
-    private lateinit var memberInfoService: MemberInfoService
+    private lateinit var memberService: MemberService
 
     @DisplayName("내 정보 조회 - [GUEST]")
     @Test
@@ -41,7 +41,7 @@ class MemberInfoServiceTest {
 
         // when
         `when`(memberRepository.findById(memberId)).thenReturn(Optional.of(expectedMember))
-        val result = memberInfoService.getById(memberId)
+        val result = memberService.getById(memberId)
 
         // then
         assertEquals(expectedMember, result)

--- a/src/test/kotlin/gomushin/backend/member/facade/MemberInfoFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/member/facade/MemberInfoFacadeTest.kt
@@ -2,10 +2,9 @@ package gomushin.backend.member.facade
 
 import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.member.domain.entity.Member
-import gomushin.backend.member.domain.service.MemberInfoService
+import gomushin.backend.member.domain.service.MemberService
 import gomushin.backend.member.domain.value.Provider
 import gomushin.backend.member.domain.value.Role
-import gomushin.backend.member.dto.response.MyInfoResponse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -14,14 +13,12 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.junit.jupiter.MockitoExtension
-import org.springframework.security.core.GrantedAuthority
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
 class MemberInfoFacadeTest {
     @Mock
-    private lateinit var memberInfoService: MemberInfoService
+    private lateinit var memberService: MemberService
 
     @InjectMocks
     private lateinit var memberInfoFacade: MemberInfoFacade
@@ -52,11 +49,11 @@ class MemberInfoFacadeTest {
     @Test
     fun getMyInfo() {
         // given
-        `when`(memberInfoService.getById(customUserDetails.getId())).thenReturn(member)
+        `when`(memberService.getById(customUserDetails.getId())).thenReturn(member)
         // when
         val result = memberInfoFacade.getMemberInfo(customUserDetails)
         // then
-        verify(memberInfoService).getById(1L)
+        verify(memberService).getById(1L)
         assertEquals(member.nickname, result.nickname)
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 커플 기념일 설정
- 입대일 설정

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/638ded65-dca8-4645-8306-cfa4caa09258" />


---

## ✏️ 관련 이슈

- Resolves : #16 


---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 커플의 기념일(연애 시작일, 군입대일, 전역일) 등록 기능이 추가되었습니다.
    - 커플 연결 시, 연결된 커플 정보를 반환하도록 개선되었습니다.
- **버그 수정**
    - 커플 연결 및 기념일 등록 시, 사용자의 커플 소속 여부를 확인하여 잘못된 접근을 방지합니다.
- **API 변경**
    - 커플 연결 API의 응답이 Boolean에서 커플 정보로 변경되었습니다.
    - 커플 기념일 등록을 위한 신규 API 엔드포인트가 추가되었습니다.
- **테스트**
    - 커플 서비스 및 멤버 서비스 관련 단위 테스트가 추가 및 이름이 정정되었습니다.
- **리팩터**
    - 서비스 및 DTO, 컨트롤러 구조가 개선되어 유지보수성이 향상되었습니다.
    - 일부 서비스 및 테스트 클래스의 명칭이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->