### PR TITLE
Issue: (#31) 편지 및 댓글 CUD

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,8 +67,12 @@ dependencies {
     // configuration processor
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
+    // aws
+    implementation("software.amazon.awssdk:s3:2.30.38")
+
     implementation("org.springframework.boot:spring-boot-starter-validation")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.0.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/docker-compose-minio.yml
+++ b/docker-compose-minio.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  minio:
+    image: quay.io/minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=12345678
+    volumes:
+      - minio_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    restart: always
+volumes:
+  minio_data:

--- a/src/main/kotlin/gomushin/backend/core/configuration/s3/S3Configuration.kt
+++ b/src/main/kotlin/gomushin/backend/core/configuration/s3/S3Configuration.kt
@@ -1,0 +1,45 @@
+package gomushin.backend.core.configuration.s3
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
+import java.net.URI
+import java.time.Duration
+
+@Configuration
+class S3Configuration(
+    @Value("\${aws.s3.endpoint}") val endpoint: String,
+    @Value("\${aws.s3.accessKey}") val accessKey: String,
+    @Value("\${aws.s3.secretKey}") val secretKey: String,
+    @Value("\${aws.s3.region}") val region: String,
+) {
+    @Bean
+    fun s3Client(): S3Client {
+        return S3Client.builder()
+            .endpointOverride(URI.create(endpoint))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+                )
+            )
+            .region(Region.of(region))
+            .serviceConfiguration(
+                S3Configuration.builder()
+                    .pathStyleAccessEnabled(true)
+                    .build()
+            )
+            .overrideConfiguration(
+                ClientOverrideConfiguration.builder()
+                    .apiCallTimeout(Duration.ofSeconds(30))
+                    .apiCallAttemptTimeout(Duration.ofSeconds(10))
+                    .build()
+            )
+            .build()
+    }
+}

--- a/src/main/kotlin/gomushin/backend/core/service/S3Service.kt
+++ b/src/main/kotlin/gomushin/backend/core/service/S3Service.kt
@@ -1,0 +1,43 @@
+package gomushin.backend.core.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import java.util.*
+
+@Service
+class S3Service(
+    private val s3Client: S3Client,
+    @Value("\${aws.s3.endpoint}") val endpoint: String,
+    @Value("\${aws.s3.bucket}") private val bucket: String,
+) {
+
+    @Transactional
+    fun uploadFile(multipartFile: MultipartFile): String {
+
+        val fileName = generateFileName(multipartFile)
+
+        s3Client.putObject(
+            PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .contentType(multipartFile.contentType)
+                .build(),
+            RequestBody.fromInputStream(multipartFile.inputStream, multipartFile.size)
+        )
+
+        return getFileUrl(fileName)
+    }
+
+    private fun getFileUrl(fileName: String): String {
+        val normalizedEndpoint = endpoint.removeSuffix("/")
+        return "$normalizedEndpoint/$bucket/$fileName"
+    }
+
+    private fun generateFileName(file: MultipartFile) =
+        "${UUID.randomUUID()}-${file.originalFilename?.replace(" ", "_")}"
+}

--- a/src/main/kotlin/gomushin/backend/core/service/S3Service.kt
+++ b/src/main/kotlin/gomushin/backend/core/service/S3Service.kt
@@ -38,6 +38,8 @@ class S3Service(
         return "$normalizedEndpoint/$bucket/$fileName"
     }
 
-    private fun generateFileName(file: MultipartFile) =
-        "${UUID.randomUUID()}-${file.originalFilename?.replace(" ", "_")}"
+    private fun generateFileName(file: MultipartFile): String {
+        val safeName = file.originalFilename?.replace(" ", "_") ?: "unknown-file"
+        return "${UUID.randomUUID()}-$safeName"
+    }
 }

--- a/src/main/kotlin/gomushin/backend/core/service/S3Service.kt
+++ b/src/main/kotlin/gomushin/backend/core/service/S3Service.kt
@@ -33,6 +33,15 @@ class S3Service(
         return getFileUrl(fileName)
     }
 
+    @Transactional
+    fun deleteFile(fileName: String) {
+        s3Client.deleteObject { it.bucket(bucket).key(fileName) }
+    }
+
+    private fun getFileName(fileUrl: String): String {
+        return fileUrl.substringAfterLast("/")
+    }
+
     private fun getFileUrl(fileName: String): String {
         val normalizedEndpoint = endpoint.removeSuffix("/")
         return "$normalizedEndpoint/$bucket/$fileName"

--- a/src/main/kotlin/gomushin/backend/core/service/S3Service.kt
+++ b/src/main/kotlin/gomushin/backend/core/service/S3Service.kt
@@ -2,6 +2,7 @@ package gomushin.backend.core.service
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import software.amazon.awssdk.core.sync.RequestBody
@@ -16,7 +17,6 @@ class S3Service(
     @Value("\${aws.s3.bucket}") private val bucket: String,
 ) {
 
-    @Transactional
     fun uploadFile(multipartFile: MultipartFile): String {
 
         val fileName = generateFileName(multipartFile)
@@ -33,9 +33,8 @@ class S3Service(
         return getFileUrl(fileName)
     }
 
-    @Transactional
     fun deleteFile(fileName: String) {
-        s3Client.deleteObject { it.bucket(bucket).key(fileName) }
+        s3Client.deleteObject { it.bucket(bucket).key(getFileName(fileName)) }
     }
 
     private fun getFileName(fileUrl: String): String {

--- a/src/main/kotlin/gomushin/backend/schedule/domain/entity/Comment.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/entity/Comment.kt
@@ -1,0 +1,39 @@
+package gomushin.backend.schedule.domain.entity
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "comment")
+class Comment(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "letter_id", nullable = false)
+    val letterId: Long = 0L,
+
+    @Column(name = "author_id", nullable = false)
+    val authorId: Long = 0L,
+
+    @Column(name = "nickname", nullable = false)
+    var nickname: String = "",
+
+    @Column(name = "content", nullable = false)
+    var content: String = "",
+) {
+    companion object {
+        fun of(
+            letterId: Long,
+            authorId: Long,
+            nickname: String,
+            content: String,
+        ): Comment {
+            return Comment(
+                letterId = letterId,
+                authorId = authorId,
+                nickname = nickname,
+                content = content,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/gomushin/backend/schedule/domain/entity/Letter.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/entity/Letter.kt
@@ -1,0 +1,41 @@
+package gomushin.backend.schedule.domain.entity
+
+import gomushin.backend.core.infrastructure.jpa.shared.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "letter")
+class Letter(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "schedule_id", nullable = false)
+    val scheduleId: Long = 0L,
+
+    @Column(name = "author_id", nullable = false)
+    val authorId: Long = 0L,
+
+    @Column(name = "title", nullable = false)
+    var title: String = "",
+
+    @Column(name = "content", nullable = false)
+    var content: String = "",
+
+    ) : BaseEntity() {
+    companion object {
+        fun of(
+            scheduleId: Long,
+            authorId: Long,
+            title: String,
+            content: String,
+        ): Letter {
+            return Letter(
+                scheduleId = scheduleId,
+                authorId = authorId,
+                title = title,
+                content = content,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/gomushin/backend/schedule/domain/entity/Picture.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/entity/Picture.kt
@@ -1,0 +1,29 @@
+package gomushin.backend.schedule.domain.entity
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "picture")
+class Picture(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "letter_id", nullable = false)
+    val letterId: Long = 0L,
+
+    @Column(name = "picture_url", nullable = false)
+    val pictureUrl: String = "",
+) {
+    companion object {
+        fun of(
+            letterId: Long,
+            pictureUrl: String,
+        ): Picture {
+            return Picture(
+                letterId = letterId,
+                pictureUrl = pictureUrl,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/CommentRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/CommentRepository.kt
@@ -1,0 +1,6 @@
+package gomushin.backend.schedule.domain.repository
+
+import gomushin.backend.schedule.domain.entity.Comment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentRepository: JpaRepository<Comment, Long>

--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
@@ -1,0 +1,6 @@
+package gomushin.backend.schedule.domain.repository
+
+import gomushin.backend.schedule.domain.entity.Letter
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface LetterRepository : JpaRepository<Letter, Long>

--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/PictureRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/PictureRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface PictureRepository: JpaRepository<Picture, Long> {
     fun findAllByPictureUrlIn(urls: List<String>): List<Picture>
     fun deleteAllByLetterId(letterId: Long)
+    fun findAllByLetterId(letterId: Long): List<Picture>
 }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/PictureRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/PictureRepository.kt
@@ -1,0 +1,9 @@
+package gomushin.backend.schedule.domain.repository
+
+import gomushin.backend.schedule.domain.entity.Picture
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PictureRepository: JpaRepository<Picture, Long> {
+    fun findAllByPictureUrlIn(urls: List<String>): List<Picture>
+    fun deleteAllByLetterId(letterId: Long)
+}

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/CommentService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/CommentService.kt
@@ -1,0 +1,59 @@
+package gomushin.backend.schedule.domain.service
+
+import gomushin.backend.core.infrastructure.exception.BadRequestException
+import gomushin.backend.schedule.domain.entity.Comment
+import gomushin.backend.schedule.domain.repository.CommentRepository
+import gomushin.backend.schedule.dto.UpsertCommentRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CommentService(
+    private val commentRepository: CommentRepository,
+) {
+    @Transactional
+    fun upsert(
+        id: Long?,
+        letterId: Long,
+        authorId: Long,
+        nickname: String,
+        upsertCommentRequest: UpsertCommentRequest
+    ) {
+        id?.let { commentId ->
+            getById(commentId).let {
+                if (it.authorId != authorId) {
+                    throw BadRequestException("sarangggun.comment.unauthorized")
+                }
+                it.content = upsertCommentRequest.content
+            }
+        } ?: save(
+            Comment.of(
+                letterId = letterId,
+                authorId = authorId,
+                nickname = nickname,
+                content = upsertCommentRequest.content,
+            )
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getById(id: Long): Comment {
+        return findById(id) ?: throw BadRequestException("sarangggun.comment.not-found")
+    }
+
+    @Transactional(readOnly = true)
+    fun findById(id: Long): Comment? {
+        return commentRepository.findByIdOrNull(id)
+    }
+
+    @Transactional
+    fun save(comment: Comment): Comment {
+        return commentRepository.save(comment)
+    }
+
+    @Transactional
+    fun delete(id: Long) {
+        commentRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
@@ -1,9 +1,9 @@
 package gomushin.backend.schedule.domain.service
 
+import gomushin.backend.core.infrastructure.exception.BadRequestException
 import gomushin.backend.schedule.domain.entity.Letter
 import gomushin.backend.schedule.domain.repository.LetterRepository
 import gomushin.backend.schedule.dto.UpsertLetterRequest
-import org.apache.coyote.BadRequestException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
@@ -1,0 +1,48 @@
+package gomushin.backend.schedule.domain.service
+
+import gomushin.backend.schedule.domain.entity.Letter
+import gomushin.backend.schedule.domain.repository.LetterRepository
+import gomushin.backend.schedule.dto.UpsertLetterRequest
+import org.apache.coyote.BadRequestException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class LetterService(
+    private val letterRepository: LetterRepository,
+) {
+    @Transactional
+    fun upsert(authorId: Long, upsertLetterRequest: UpsertLetterRequest): Letter {
+        return upsertLetterRequest.letterId?.let { letterId ->
+            getById(letterId).apply {
+                title = upsertLetterRequest.title
+                content = upsertLetterRequest.content
+            }.let { savedLetter ->
+                save(savedLetter)
+            }
+        } ?: save(
+            Letter.of(
+                scheduleId = upsertLetterRequest.scheduleId,
+                authorId = authorId,
+                title = upsertLetterRequest.title,
+                content = upsertLetterRequest.content,
+            )
+        )
+
+    }
+
+    @Transactional(readOnly = true)
+    fun getById(id: Long) = findById(id) ?: throw BadRequestException("sarangggun.letter.not-exist")
+
+    @Transactional(readOnly = true)
+    fun findById(id: Long) = letterRepository.findByIdOrNull(id)
+
+    @Transactional
+    fun save(letter: Letter) = letterRepository.save(letter)
+
+    @Transactional
+    fun delete(letterId: Long) {
+        letterRepository.deleteById(letterId)
+    }
+}

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/PictureService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/PictureService.kt
@@ -1,0 +1,33 @@
+package gomushin.backend.schedule.domain.service
+
+import gomushin.backend.schedule.domain.entity.Picture
+import gomushin.backend.schedule.domain.repository.PictureRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class PictureService(
+    private val pictureRepository: PictureRepository,
+) {
+    @Transactional
+    fun upsert(letterId: Long, pictureUrls: List<String>) {
+        deleteAllByLetterId(letterId)
+        val newPictures = pictureUrls.map { Picture(letterId = letterId, pictureUrl = it) }
+        saveAll(newPictures)
+    }
+
+    @Transactional(readOnly = true)
+    fun findAll(urls: List<String>): List<Picture> {
+        return pictureRepository.findAllByPictureUrlIn(urls)
+    }
+
+    @Transactional
+    fun saveAll(pictures: List<Picture>): List<Picture> {
+        return pictureRepository.saveAll(pictures)
+    }
+
+    @Transactional
+    fun deleteAllByLetterId(letterId: Long) {
+        pictureRepository.deleteAllByLetterId(letterId)
+    }
+}

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/PictureService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/PictureService.kt
@@ -21,6 +21,11 @@ class PictureService(
         return pictureRepository.findAllByPictureUrlIn(urls)
     }
 
+    @Transactional(readOnly = true)
+    fun findAllByLetterId(letterId: Long): List<Picture> {
+        return pictureRepository.findAllByLetterId(letterId)
+    }
+
     @Transactional
     fun saveAll(pictures: List<Picture>): List<Picture> {
         return pictureRepository.saveAll(pictures)

--- a/src/main/kotlin/gomushin/backend/schedule/dto/UpsertCommentRequest.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/UpsertCommentRequest.kt
@@ -1,0 +1,10 @@
+package gomushin.backend.schedule.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class UpsertCommentRequest(
+    @Schema(description = "댓글 ID(새로 생성 시 null, 업데이트 시 id)", example = "1")
+    val commentId: Long?,
+    @Schema(description = "내용", example = "훈련 힘내")
+    val content: String,
+)

--- a/src/main/kotlin/gomushin/backend/schedule/dto/UpsertLetterRequest.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/UpsertLetterRequest.kt
@@ -1,0 +1,14 @@
+package gomushin.backend.schedule.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class UpsertLetterRequest(
+    @Schema(description = "편지 ID(새로 생성 시 null, 업데이트 시 id)", example = "1")
+    val letterId: Long? = null,
+    @Schema(description = "일정 ID", example = "1")
+    val scheduleId: Long,
+    @Schema(description = "편지 제목", example = "훈련 힘내")
+    val title: String,
+    @Schema(description = "편지 내용", example = "화이팅")
+    val content: String,
+)

--- a/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteCommentFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteCommentFacade.kt
@@ -1,0 +1,43 @@
+package gomushin.backend.schedule.facade
+
+import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.core.infrastructure.exception.BadRequestException
+import gomushin.backend.member.domain.service.MemberService
+import gomushin.backend.schedule.domain.service.CommentService
+import gomushin.backend.schedule.domain.service.LetterService
+import gomushin.backend.schedule.dto.UpsertCommentRequest
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class UpsertAndDeleteCommentFacade(
+    private val commentService: CommentService,
+    private val letterService: LetterService,
+    private val memberService: MemberService,
+) {
+    @Transactional
+    fun upsert(customUserDetails: CustomUserDetails, letterId: Long, upsertCommentRequest: UpsertCommentRequest) {
+        val member = memberService.getById(customUserDetails.getId())
+        val letter = letterService.getById(letterId)
+        commentService.upsert(
+            id = upsertCommentRequest.commentId,
+            letterId = letter.id,
+            authorId = member.id,
+            nickname = member.nickname,
+            upsertCommentRequest = upsertCommentRequest
+        )
+    }
+
+    @Transactional
+    fun delete(customUserDetails: CustomUserDetails, letterId: Long, commentId: Long) {
+        val member = memberService.getById(customUserDetails.getId())
+        val comment = commentService.getById(commentId)
+        if (comment.authorId != member.id) {
+            throw BadRequestException("sarangggun.comment.unauthorized")
+        }
+        if (comment.letterId != letterId) {
+            throw BadRequestException("sarangggun.comment.invalid-letter")
+        }
+        commentService.delete(commentId)
+    }
+}

--- a/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteLetterFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteLetterFacade.kt
@@ -18,7 +18,7 @@ class UpsertAndDeleteLetterFacade(
     private val pictureService: PictureService,
     private val scheduleService: ScheduleService,
 ) {
-
+    // TODO: 이벤트 드리븐하게 수정
     @Transactional
     fun upsert(
         customUserDetails: CustomUserDetails,

--- a/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteLetterFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteLetterFacade.kt
@@ -64,6 +64,12 @@ class UpsertAndDeleteLetterFacade(
             throw BadRequestException("sarangggun.letter.invalid-schedule")
         }
 
+        pictureService.findAllByLetterId(letter.id)
+            .takeIf { it.isNotEmpty() }
+            ?.forEach { picture ->
+                s3Service.deleteFile(picture.pictureUrl)
+            }
+
         letterService.delete(letterId)
         pictureService.deleteAllByLetterId(letterId)
     }

--- a/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteLetterFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteLetterFacade.kt
@@ -1,0 +1,61 @@
+package gomushin.backend.schedule.facade
+
+import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.core.infrastructure.exception.BadRequestException
+import gomushin.backend.core.service.S3Service
+import gomushin.backend.schedule.domain.service.LetterService
+import gomushin.backend.schedule.domain.service.PictureService
+import gomushin.backend.schedule.dto.UpsertLetterRequest
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+
+@Component
+class UpsertAndDeleteLetterFacade(
+    private val letterService: LetterService,
+    private val s3Service: S3Service,
+    private val pictureService: PictureService
+) {
+
+    @Transactional
+    fun upsert(
+        customUserDetails: CustomUserDetails,
+        upsertLetterRequest: UpsertLetterRequest,
+        pictures: List<MultipartFile>?
+    ) {
+        val letter = letterService.upsert(
+            customUserDetails.getId(),
+            upsertLetterRequest
+        )
+
+        val pictureList = mutableListOf<String>()
+
+        pictures?.let {
+            it.forEach { picture ->
+                val fileUrl = s3Service.uploadFile(picture)
+                pictureList.add(fileUrl)
+            }
+            pictureService.upsert(letter.id, pictureList)
+        }
+    }
+
+    @Transactional
+    fun delete(
+        customUserDetails: CustomUserDetails,
+        scheduleId: Long,
+        letterId: Long
+    ) {
+        val letter = letterService.getById(letterId)
+
+        if (letter.authorId != customUserDetails.getId()) {
+            throw BadRequestException("sarangggun.letter.unauthorized")
+        }
+
+        if (letter.scheduleId != scheduleId) {
+            throw BadRequestException("sarangggun.letter.invalid-schedule")
+        }
+
+        letterService.delete(letterId)
+        pictureService.deleteAllByLetterId(letterId)
+    }
+}

--- a/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteLetterFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteLetterFacade.kt
@@ -5,6 +5,7 @@ import gomushin.backend.core.infrastructure.exception.BadRequestException
 import gomushin.backend.core.service.S3Service
 import gomushin.backend.schedule.domain.service.LetterService
 import gomushin.backend.schedule.domain.service.PictureService
+import gomushin.backend.schedule.domain.service.ScheduleService
 import gomushin.backend.schedule.dto.UpsertLetterRequest
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -14,7 +15,8 @@ import org.springframework.web.multipart.MultipartFile
 class UpsertAndDeleteLetterFacade(
     private val letterService: LetterService,
     private val s3Service: S3Service,
-    private val pictureService: PictureService
+    private val pictureService: PictureService,
+    private val scheduleService: ScheduleService,
 ) {
 
     @Transactional
@@ -23,6 +25,13 @@ class UpsertAndDeleteLetterFacade(
         upsertLetterRequest: UpsertLetterRequest,
         pictures: List<MultipartFile>?
     ) {
+
+        val schedule = scheduleService.getById(upsertLetterRequest.scheduleId)
+
+        if (schedule.coupleId != customUserDetails.getCouple().id) {
+            throw BadRequestException("sarangggun.letter.not-in-couple")
+        }
+
         val letter = letterService.upsert(
             customUserDetails.getId(),
             upsertLetterRequest

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/ApiPath.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/ApiPath.kt
@@ -3,4 +3,10 @@ package gomushin.backend.schedule.presentation
 object ApiPath {
     const val SCHEDULES = "/v1/schedules"
     const val SCHEDULE = "/v1/schedules/{scheduleId}"
+
+    const val LETTERS = "/v1/schedules/letters"
+    const val LETTER = "/v1/schedules/{scheduleId}/letters/{letterId}"
+
+    const val COMMENTS = "/v1/schedules/letters/{letterId}/comments"
+    const val COMMENT = "/v1/schedules/letters/{letterId}/comments/{commentId}"
 }

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/UpsertAndDeleteCommentController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/UpsertAndDeleteCommentController.kt
@@ -1,0 +1,47 @@
+package gomushin.backend.schedule.presentation
+
+import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.core.common.web.response.ApiResponse
+import gomushin.backend.schedule.dto.UpsertCommentRequest
+import gomushin.backend.schedule.facade.UpsertAndDeleteCommentFacade
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@Tag(name = "댓글 생성 , 수정 , 삭제", description = "UpsertAndDeleteCommentController")
+class UpsertAndDeleteCommentController(
+    private val upsertAndDeleteCommentFacade: UpsertAndDeleteCommentFacade,
+) {
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping(ApiPath.COMMENTS)
+    @Operation(summary = "댓글 수정하거나 추가하기", description = "upsertComment")
+    fun upsertComment(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @PathVariable letterId: Long,
+        @RequestBody upsertCommentRequest: UpsertCommentRequest,
+    ): ApiResponse<Boolean> {
+        upsertAndDeleteCommentFacade.upsert(customUserDetails, letterId, upsertCommentRequest)
+        return ApiResponse.success(true)
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping(ApiPath.COMMENT)
+    @Operation(summary = "댓글 삭제하기", description = "deleteComment")
+    fun deleteComment(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @PathVariable letterId: Long,
+        @PathVariable commentId: Long,
+    ): ApiResponse<Boolean> {
+        upsertAndDeleteCommentFacade.delete(customUserDetails, letterId, commentId)
+        return ApiResponse.success(true)
+    }
+}

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/UpsertAndDeleteLetterController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/UpsertAndDeleteLetterController.kt
@@ -1,0 +1,46 @@
+package gomushin.backend.schedule.presentation
+
+import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.core.common.web.response.ApiResponse
+import gomushin.backend.schedule.dto.UpsertLetterRequest
+import gomushin.backend.schedule.facade.UpsertAndDeleteLetterFacade
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@Tag(name = "편지 생성 , 수정 , 삭제", description = "UpsertAndDeleteLetterController")
+class UpsertAndDeleteLetterController(
+    private val upsertAndDeleteLetterFacade: UpsertAndDeleteLetterFacade,
+) {
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping(
+        ApiPath.LETTERS,
+        consumes = [MediaType.MULTIPART_FORM_DATA_VALUE]
+    )
+    @Operation(summary = "편지 수정하거나 추가하기", description = "upsertLetter")
+    fun upsertLetter(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @RequestPart("data") upsertLetterRequest: UpsertLetterRequest,
+        @RequestPart("pictures", required = false) pictures: List<MultipartFile>?,
+    ): ApiResponse<Boolean> {
+        upsertAndDeleteLetterFacade.upsert(customUserDetails, upsertLetterRequest, pictures)
+        return ApiResponse.success(true)
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping(ApiPath.LETTER)
+    @Operation(summary = "편지 삭제하기", description = "deleteLetter")
+    fun deleteLetter(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @PathVariable scheduleId: Long,
+        @PathVariable letterId: Long,
+    ): ApiResponse<Boolean> {
+        upsertAndDeleteLetterFacade.delete(customUserDetails, scheduleId, letterId)
+        return ApiResponse.success(true)
+    }
+}

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/UpsertAndDeleteScheduleController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/UpsertAndDeleteScheduleController.kt
@@ -11,7 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
 @RestController
-@Tag(name = "일정", description = "UpsertAndDeleteScheduleController")
+@Tag(name = "일정 생성 , 수정 , 삭제", description = "UpsertAndDeleteScheduleController")
 class UpsertAndDeleteScheduleController(
     private val upsertAndDeleteScheduleFacade: UpsertAndDeleteScheduleFacade,
 ) {

--- a/src/test/kotlin/gomushin/backend/schedule/domain/facade/UpsertAndDeleteCommentFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/schedule/domain/facade/UpsertAndDeleteCommentFacadeTest.kt
@@ -1,0 +1,98 @@
+package gomushin.backend.schedule.domain.facade
+
+import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.member.domain.entity.Member
+import gomushin.backend.member.domain.service.MemberService
+import gomushin.backend.schedule.domain.entity.Comment
+import gomushin.backend.schedule.domain.entity.Letter
+import gomushin.backend.schedule.domain.service.CommentService
+import gomushin.backend.schedule.domain.service.LetterService
+import gomushin.backend.schedule.dto.UpsertCommentRequest
+import gomushin.backend.schedule.facade.UpsertAndDeleteCommentFacade
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import kotlin.test.Test
+
+@ExtendWith(MockitoExtension::class)
+class UpsertAndDeleteCommentFacadeTest {
+
+    @Mock
+    private lateinit var commentService: CommentService
+
+    @Mock
+    private lateinit var letterService: LetterService
+
+    @Mock
+    private lateinit var memberService: MemberService
+
+    @InjectMocks
+    private lateinit var upsertAndDeleteCommentFacade: UpsertAndDeleteCommentFacade
+
+    @DisplayName("댓글 생성 또는 수정 성공")
+    @Test
+    fun upsert_success() {
+        // given
+        val customUserDetails = mock(CustomUserDetails::class.java)
+        val letterId = 1L
+        val memberId = 1L
+        val upsertCommentRequest = UpsertCommentRequest(
+            commentId = null,
+            content = "댓글 내용"
+        )
+
+        val mockMember = mock(Member::class.java).apply {
+            `when`(id).thenReturn(memberId)
+            `when`(nickname).thenReturn("테스트유저")
+        }
+        val mockLetter = mock(Letter::class.java).apply {
+            `when`(id).thenReturn(letterId)
+        }
+
+        `when`(customUserDetails.getId()).thenReturn(memberId)
+        `when`(memberService.getById(memberId)).thenReturn(mockMember)
+        `when`(letterService.getById(letterId)).thenReturn(mockLetter)
+
+        // when
+        upsertAndDeleteCommentFacade.upsert(customUserDetails, letterId, upsertCommentRequest)
+
+        // then
+        verify(commentService, times(1)).upsert(
+            id = upsertCommentRequest.commentId,
+            letterId = mockLetter.id,
+            authorId = mockMember.id,
+            nickname = "테스트유저",
+            upsertCommentRequest = upsertCommentRequest
+        )
+    }
+
+    @DisplayName("댓글 삭제 성공")
+    @Test
+    fun delete_success() {
+        // given
+        val customUserDetails = mock(CustomUserDetails::class.java)
+        val letterId = 1L
+        val commentId = 1L
+        val mockMember = mock(Member::class.java)
+        val mockComment = mock(Comment::class.java)
+
+        // when
+        `when`(customUserDetails.getId()).thenReturn(1L)
+        `when`(memberService.getById(customUserDetails.getId())).thenReturn(mockMember)
+        `when`(commentService.getById(commentId)).thenReturn(mockComment)
+        `when`(mockMember.id).thenReturn(1L)
+        `when`(mockComment.authorId).thenReturn(1L)
+        `when`(mockComment.letterId).thenReturn(letterId)
+        `when`(mockComment.letterId).thenReturn(letterId)
+
+        upsertAndDeleteCommentFacade.delete(customUserDetails, letterId, commentId)
+
+        // then
+        verify(memberService, times(1)).getById(customUserDetails.getId())
+        verify(commentService, times(1)).getById(commentId)
+        verify(commentService, times(1)).delete(commentId)
+    }
+}

--- a/src/test/kotlin/gomushin/backend/schedule/domain/facade/UpsertAndDeleteLetterFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/schedule/domain/facade/UpsertAndDeleteLetterFacadeTest.kt
@@ -2,9 +2,12 @@ package gomushin.backend.schedule.domain.facade
 
 import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.core.service.S3Service
+import gomushin.backend.couple.domain.entity.Couple
 import gomushin.backend.schedule.domain.entity.Letter
+import gomushin.backend.schedule.domain.entity.Schedule
 import gomushin.backend.schedule.domain.service.LetterService
 import gomushin.backend.schedule.domain.service.PictureService
+import gomushin.backend.schedule.domain.service.ScheduleService
 import gomushin.backend.schedule.dto.UpsertLetterRequest
 import gomushin.backend.schedule.facade.UpsertAndDeleteLetterFacade
 import org.junit.jupiter.api.DisplayName
@@ -29,6 +32,9 @@ class UpsertAndDeleteLetterFacadeTest {
     @Mock
     private lateinit var pictureService: PictureService
 
+    @Mock
+    private lateinit var scheduleService: ScheduleService
+
     @InjectMocks
     private lateinit var upsertAndDeleteLetterFacade: UpsertAndDeleteLetterFacade
 
@@ -47,12 +53,17 @@ class UpsertAndDeleteLetterFacadeTest {
                 scheduleId = 1L
             )
             val pictures = listOf(mock(MultipartFile::class.java))
-
+            val schedule = mock(Schedule::class.java)
             val letter = mock(Letter::class.java)
+            val couple = mock(Couple::class.java)
 
             // when
             `when`(letter.id).thenReturn(1L)
             `when`(customUserDetails.getId()).thenReturn(1L)
+            `when`(scheduleService.getById(upsertLetterRequest.scheduleId)).thenReturn(schedule)
+            `when`(customUserDetails.getCouple()).thenReturn(couple)
+            `when`(customUserDetails.getCouple().id).thenReturn(1L)
+            `when`(schedule.coupleId).thenReturn(1L)
             `when`(letterService.upsert(1L, upsertLetterRequest)).thenReturn(letter)
             `when`(s3Service.uploadFile(pictures[0])).thenReturn("http://example.com/test.jpg")
             doNothing().`when`(pictureService).upsert(1L, listOf("http://example.com/test.jpg"))
@@ -77,9 +88,15 @@ class UpsertAndDeleteLetterFacadeTest {
             )
             val pictures: List<MultipartFile>? = null
             val letter = mock(Letter::class.java)
+            val couple = mock(Couple::class.java)
+            val schedule = mock(Schedule::class.java)
 
             // when
             `when`(customUserDetails.getId()).thenReturn(1L)
+            `when`(scheduleService.getById(upsertLetterRequest.scheduleId)).thenReturn(schedule)
+            `when`(customUserDetails.getCouple()).thenReturn(couple)
+            `when`(customUserDetails.getCouple().id).thenReturn(1L)
+            `when`(schedule.coupleId).thenReturn(1L)
             `when`(letterService.upsert(1L, upsertLetterRequest)).thenReturn(letter)
             upsertAndDeleteLetterFacade.upsert(customUserDetails, upsertLetterRequest, pictures)
 

--- a/src/test/kotlin/gomushin/backend/schedule/domain/facade/UpsertAndDeleteLetterFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/schedule/domain/facade/UpsertAndDeleteLetterFacadeTest.kt
@@ -1,0 +1,119 @@
+package gomushin.backend.schedule.domain.facade
+
+import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.core.service.S3Service
+import gomushin.backend.schedule.domain.entity.Letter
+import gomushin.backend.schedule.domain.service.LetterService
+import gomushin.backend.schedule.domain.service.PictureService
+import gomushin.backend.schedule.dto.UpsertLetterRequest
+import gomushin.backend.schedule.facade.UpsertAndDeleteLetterFacade
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.web.multipart.MultipartFile
+
+@ExtendWith(MockitoExtension::class)
+class UpsertAndDeleteLetterFacadeTest {
+
+    @Mock
+    private lateinit var letterService: LetterService
+
+    @Mock
+    private lateinit var s3Service: S3Service
+
+    @Mock
+    private lateinit var pictureService: PictureService
+
+    @InjectMocks
+    private lateinit var upsertAndDeleteLetterFacade: UpsertAndDeleteLetterFacade
+
+
+    @Nested
+    inner class Upsert {
+
+        @DisplayName("업로드 성공 - 업로드된 사진이 있을 때")
+        @Test
+        fun upsertWithPictures_success() {
+            // given
+            val customUserDetails = mock(CustomUserDetails::class.java)
+            val upsertLetterRequest = UpsertLetterRequest(
+                title = "제목",
+                content = "내용",
+                scheduleId = 1L
+            )
+            val pictures = listOf(mock(MultipartFile::class.java))
+
+            val letter = mock(Letter::class.java)
+
+            // when
+            `when`(letter.id).thenReturn(1L)
+            `when`(customUserDetails.getId()).thenReturn(1L)
+            `when`(letterService.upsert(1L, upsertLetterRequest)).thenReturn(letter)
+            `when`(s3Service.uploadFile(pictures[0])).thenReturn("http://example.com/test.jpg")
+            doNothing().`when`(pictureService).upsert(1L, listOf("http://example.com/test.jpg"))
+            upsertAndDeleteLetterFacade.upsert(customUserDetails, upsertLetterRequest, pictures)
+
+            // then
+            verify(
+                letterService,
+                times(1)
+            ).upsert(1L, upsertLetterRequest)
+        }
+
+        @DisplayName("업로드 성공 - 업로드된 사진이 없을 때")
+        @Test
+        fun upsertWithoutPictures_success() {
+            // given
+            val customUserDetails = mock(CustomUserDetails::class.java)
+            val upsertLetterRequest = UpsertLetterRequest(
+                title = "제목",
+                content = "내용",
+                scheduleId = 1L
+            )
+            val pictures: List<MultipartFile>? = null
+            val letter = mock(Letter::class.java)
+
+            // when
+            `when`(customUserDetails.getId()).thenReturn(1L)
+            `when`(letterService.upsert(1L, upsertLetterRequest)).thenReturn(letter)
+            upsertAndDeleteLetterFacade.upsert(customUserDetails, upsertLetterRequest, pictures)
+
+            // then
+            verify(letterService, times(1)).upsert(1L, upsertLetterRequest)
+            verify(s3Service, never()).uploadFile(org.mockito.kotlin.any())
+            verify(pictureService, never()).upsert(org.mockito.kotlin.any(), org.mockito.kotlin.any())
+        }
+    }
+
+    @DisplayName("삭제 성공")
+    @Test
+    fun delete_success() {
+        // given
+        val customUserDetails = mock(CustomUserDetails::class.java)
+        val scheduleId = 1L
+        val letterId = 1L
+        val mockLetter = mock(Letter::class.java)
+
+        // when
+        `when`(letterService.getById(letterId)).thenReturn(mockLetter)
+        `when`(customUserDetails.getId()).thenReturn(1L)
+        `when`(mockLetter.authorId).thenReturn(1L)
+        `when`(mockLetter.scheduleId).thenReturn(scheduleId)
+        upsertAndDeleteLetterFacade.delete(
+            customUserDetails,
+            scheduleId,
+            letterId
+        )
+
+        // then
+        verify(letterService, times(1)).getById(letterId)
+        verify(letterService, times(1)).delete(letterId)
+        verify(pictureService, times(1)).deleteAllByLetterId(letterId)
+
+    }
+}

--- a/src/test/kotlin/gomushin/backend/schedule/domain/service/CommentServiceTest.kt
+++ b/src/test/kotlin/gomushin/backend/schedule/domain/service/CommentServiceTest.kt
@@ -1,0 +1,74 @@
+package gomushin.backend.schedule.domain.service
+
+import gomushin.backend.schedule.domain.entity.Comment
+import gomushin.backend.schedule.domain.repository.CommentRepository
+import gomushin.backend.schedule.dto.UpsertCommentRequest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import java.util.*
+import kotlin.test.Test
+
+@ExtendWith(MockitoExtension::class)
+class CommentServiceTest {
+
+    @Mock
+    lateinit var commentRepository: CommentRepository
+
+    @InjectMocks
+    lateinit var commentService: CommentService
+
+    @Nested
+    inner class Upsert {
+
+        @DisplayName("업데이트 성공 - 댓글이 존재할 때")
+        @Test
+        fun upload_success() {
+            // given
+            val id = 1L
+            val letterId = 1L
+            val authorId = 1L
+            val nickname = "닉네임"
+            val upsertCommentRequest = UpsertCommentRequest(
+                commentId = 1L,
+                content = "내용"
+            )
+            val mockComment = mock(Comment::class.java).apply {
+                `when`(this.authorId).thenReturn(authorId)
+            }
+
+            // when
+            `when`(commentRepository.findById(id)).thenReturn(Optional.of(mockComment))
+            commentService.upsert(id, letterId, authorId, nickname, upsertCommentRequest)
+
+            // then
+            verify(mockComment).content = upsertCommentRequest.content
+        }
+
+        @DisplayName("댓글 생성 성공")
+        @Test
+        fun insert_success() {
+            // given
+            val letterId = 1L
+            val authorId = 1L
+            val nickname = "닉네임"
+            val upsertCommentRequest = UpsertCommentRequest(
+                commentId = null,
+                content = "내용"
+            )
+            val mockComment = mock(Comment::class.java)
+
+            // when
+            `when`(commentRepository.save(any())).thenReturn(mockComment)
+            commentService.upsert(null, letterId, authorId, nickname, upsertCommentRequest)
+
+            // then
+            verify(commentRepository, times(1)).save(org.mockito.kotlin.any())
+        }
+
+    }
+}

--- a/src/test/kotlin/gomushin/backend/schedule/domain/service/PictureServiceTest.kt
+++ b/src/test/kotlin/gomushin/backend/schedule/domain/service/PictureServiceTest.kt
@@ -1,0 +1,37 @@
+package gomushin.backend.schedule.domain.service
+
+import gomushin.backend.schedule.domain.repository.PictureRepository
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.anyList
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.times
+import kotlin.test.Test
+
+@ExtendWith(MockitoExtension::class)
+class PictureServiceTest {
+
+    @Mock
+    private lateinit var pictureRepository: PictureRepository
+
+    @InjectMocks
+    private lateinit var pictureService: PictureService
+
+    @DisplayName("upsert 성공")
+    @Test
+    fun upsert_success() {
+        // given
+        val letterId = 1L
+        val pictureUrls = listOf("http://example.com/test.jpg")
+
+        // when
+        pictureService.upsert(letterId, pictureUrls)
+
+        // then
+        verify(pictureRepository).deleteAllByLetterId(letterId)
+        verify(pictureRepository, times(1)).saveAll(anyList())
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 일정 및 편지 CUD
- s3 설정 추가

---

## ✏️ 관련 이슈

- Resolves : #31 

## 🎸 기타 사항 or 추가 코멘트

편지랑 편지에 댓글 까지 생성, 수정, 삭제 PR이야.
시간이 없어서 PR이 좀 커
환경변수(local, test)랑 에러 코드도 업데이트 했어

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 일정의 편지 및 댓글 생성, 수정, 삭제를 위한 API 엔드포인트가 추가되었습니다.
  - 편지에 사진 업로드 및 S3 연동 기능이 도입되었습니다.
  - 댓글 및 편지 관련 도메인 엔티티와 서비스가 추가되었습니다.
  - MinIO를 통한 S3 호환 스토리지 로컬 환경 구성이 지원됩니다.

- **문서화**
  - Swagger를 통한 API 문서에 편지 및 댓글 관련 엔드포인트가 반영되었습니다.

- **테스트**
  - 편지 및 댓글 생성/수정/삭제, 사진 관리 서비스에 대한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->