### PR TITLE
Issue: (#47) 나에게 온 편지 조회

### DIFF
--- a/src/main/kotlin/gomushin/backend/core/common/web/PageResponse.kt
+++ b/src/main/kotlin/gomushin/backend/core/common/web/PageResponse.kt
@@ -1,0 +1,34 @@
+package gomushin.backend.core.common.web
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class PageResponse<T>(
+    @Schema(description = "페이지 응답")
+    val data: List<T>?,
+    @Schema(description = "다음 페이지를 위한 커서 키")
+    val after: Long?,
+    @Schema(description = "데이터 수")
+    val count: Int,
+    @Schema(description = "다음 페이지 URL")
+    val next: String?,
+    @Schema(description = "마지막 페이지 여부")
+    val isLastPage: Boolean,
+) {
+    companion object {
+        fun <T> of(
+            data: List<T>,
+            after: Long?,
+            count: Int,
+            next: String?,
+            isLastPage: Boolean,
+        ): PageResponse<T> {
+            return PageResponse(
+                data = data,
+                after = after,
+                count = count,
+                next = next,
+                isLastPage = isLastPage
+            )
+        }
+    }
+}

--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
@@ -17,4 +17,24 @@ interface LetterRepository : JpaRepository<Letter, Long> {
     @Modifying
     @Query("DELETE FROM Letter l WHERE l.authorId = :authorId")
     fun deleteAllByAuthorId(@Param("authorId") authorId: Long)
+
+    @Query(
+        """
+            SELECT *
+            FROM Letter l 
+            WHERE l.couple_id = :coupleId 
+                AND l.author_id = :partnerPk
+                AND l.id <:key
+            ORDER BY l.created_at DESC         
+            LIMIT :take
+        """,
+        nativeQuery = true
+    )
+    fun findByLettersToMe(
+        @Param("coupleId") coupleId: Long,
+        @Param("partnerPk") partnerPk: Long,
+        @Param("key") key: Long,
+        @Param("take") take: Long,
+        @Param("orderCreatedAt") orderCreatedAt: String,
+    ): List<Letter?>
 }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
@@ -35,6 +35,5 @@ interface LetterRepository : JpaRepository<Letter, Long> {
         @Param("partnerPk") partnerPk: Long,
         @Param("key") key: Long,
         @Param("take") take: Long,
-        @Param("orderCreatedAt") orderCreatedAt: String,
     ): List<Letter?>
 }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
@@ -88,7 +88,6 @@ class LetterService(
             partnerPk,
             readLettersToMePaginationRequest.key,
             readLettersToMePaginationRequest.take,
-            readLettersToMePaginationRequest.orderCreatedAt
         )
     }
 }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
@@ -5,6 +5,7 @@ import gomushin.backend.couple.domain.entity.Couple
 import gomushin.backend.schedule.domain.entity.Letter
 import gomushin.backend.schedule.domain.entity.Schedule
 import gomushin.backend.schedule.domain.repository.LetterRepository
+import gomushin.backend.schedule.dto.request.ReadLettersToMePaginationRequest
 import gomushin.backend.schedule.dto.request.UpsertLetterRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -65,13 +66,29 @@ class LetterService(
     fun delete(letterId: Long) {
         letterRepository.deleteById(letterId)
     }
+
     @Transactional
-    fun deleteAllByMemberId(memberId : Long) {
+    fun deleteAllByMemberId(memberId: Long) {
         letterRepository.deleteAllByAuthorId(memberId)
     }
 
     @Transactional(readOnly = true)
-    fun findAllByAuthorId(memberId: Long) : List<Long>{
+    fun findAllByAuthorId(memberId: Long): List<Long> {
         return letterRepository.findAllByAuthorId(memberId)
+    }
+
+    @Transactional(readOnly = true)
+    fun findArrivedToMe(
+        couple: Couple,
+        partnerPk: Long,
+        readLettersToMePaginationRequest: ReadLettersToMePaginationRequest
+    ): List<Letter?> {
+        return letterRepository.findByLettersToMe(
+            couple.id,
+            partnerPk,
+            readLettersToMePaginationRequest.key,
+            readLettersToMePaginationRequest.take,
+            readLettersToMePaginationRequest.orderCreatedAt
+        )
     }
 }

--- a/src/main/kotlin/gomushin/backend/schedule/dto/request/ReadLettersToMePaginationRequest.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/request/ReadLettersToMePaginationRequest.kt
@@ -1,0 +1,7 @@
+package gomushin.backend.schedule.dto.request
+
+data class ReadLettersToMePaginationRequest(
+    val key: Long = Long.MAX_VALUE,
+    val orderCreatedAt: String = "DESC",
+    val take: Long = 10L,
+)

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/ApiPath.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/ApiPath.kt
@@ -7,6 +7,7 @@ object ApiPath {
 
     const val LETTERS = "/v1/schedules/letters"
     const val LETTER = "/v1/schedules/{scheduleId}/letters/{letterId}"
+    const val LETTERS_TO_ME = "/v1/schedules/letters/to-me"
     const val LETTERS_BY_SCHEDULE = "/v1/schedules/{scheduleId}"
 
     const val COMMENTS = "/v1/schedules/letters/{letterId}/comments"

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
@@ -1,12 +1,15 @@
 package gomushin.backend.schedule.presentation
 
 import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.core.common.web.PageResponse
 import gomushin.backend.core.common.web.response.ApiResponse
+import gomushin.backend.schedule.dto.request.ReadLettersToMePaginationRequest
 import gomushin.backend.schedule.dto.response.LetterDetailResponse
 import gomushin.backend.schedule.dto.response.LetterPreviewResponse
 import gomushin.backend.schedule.facade.ReadLetterFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -37,5 +40,15 @@ class ReadLetterController(
     ): ApiResponse<LetterDetailResponse> {
         val letter = readLetterFacade.get(customUserDetails, scheduleId, letterId)
         return ApiResponse.success(letter)
+    }
+
+    @GetMapping(ApiPath.LETTERS_TO_ME)
+    @Operation(summary = "내가 받은 편지 리스트 가져오기", description = "getLetterListToMe")
+    fun getLetterListToMe(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @ParameterObject readLettersToMePaginationRequest: ReadLettersToMePaginationRequest
+    ): ApiResponse<PageResponse<LetterPreviewResponse>> {
+        val letters = readLetterFacade.getLetterListToMe(customUserDetails,readLettersToMePaginationRequest)
+        return ApiResponse.success(letters)
     }
 }

--- a/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadLetterFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadLetterFacadeTest.kt
@@ -33,7 +33,7 @@ class ReadLetterFacadeTest {
     @Mock
     lateinit var pictureService: PictureService
 
-    lateinit var readLetterFacade: ReadLetterFacade
+    private lateinit var readLetterFacade: ReadLetterFacade
 
 
     @BeforeEach

--- a/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadLetterFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadLetterFacadeTest.kt
@@ -10,9 +10,9 @@ import gomushin.backend.schedule.domain.service.LetterService
 import gomushin.backend.schedule.domain.service.PictureService
 import gomushin.backend.schedule.domain.service.ScheduleService
 import gomushin.backend.schedule.facade.ReadLetterFacade
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.junit.jupiter.MockitoExtension
@@ -33,9 +33,20 @@ class ReadLetterFacadeTest {
     @Mock
     lateinit var pictureService: PictureService
 
-    @InjectMocks
     lateinit var readLetterFacade: ReadLetterFacade
 
+
+    @BeforeEach
+    fun setUp() {
+        val baseUrl = "http://localhost:8080"
+        readLetterFacade = ReadLetterFacade(
+            letterService,
+            scheduleService,
+            pictureService,
+            commentService,
+            baseUrl
+        )
+    }
 
     @DisplayName("getList - 성공")
     @Test


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 나에게 온 편지 구현
  - 마지막 페이지인 경우
  
![스크린샷 2025-04-28 13 31 01](https://github.com/user-attachments/assets/c758e57a-df09-4254-98b5-c7edb088e946)

 - 마지막 페이지가 아닌 경우
  
![스크린샷 2025-04-28 13 33 40](https://github.com/user-attachments/assets/ab78d828-cbcf-4498-80e8-4a8c6f2b6582)

 - next 로 이동해서 요청한 경우

![스크린샷 2025-04-28 13 33 56](https://github.com/user-attachments/assets/f28c8a68-ac76-4de5-bbb1-6206ce14b63e)

- 나에게 온 편지가 없는 경우

![스크린샷 2025-04-28 13 42 32](https://github.com/user-attachments/assets/9505d1f9-e69a-40ad-813a-96e15ab51e6e)


-

---

## ✏️ 관련 이슈

- Resolves : #47 


---

## 🎸 기타 사항 or 추가 코멘트

일단은 내림차순으로 고정했어

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 사용자가 받은 편지 목록을 페이지네이션 방식으로 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
    - 편지 목록 조회 시 각 편지의 미리보기와 함께 다음 페이지로 이동할 수 있는 정보가 제공됩니다.
    - 편지 조회 시 페이지네이션 요청을 위한 파라미터(`key`, `take`, `orderCreatedAt`)가 도입되었습니다.
    - 편지 목록 조회 결과에 페이징 정보와 다음 페이지 URL이 포함되어 사용자 경험이 향상되었습니다.
    - 편지 조회 결과를 페이지 단위로 반환하는 응답 구조가 새롭게 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->