### PR TITLE
Issue: (#45) AL_01 비정기적 알림 전송

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,19 +33,22 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: YML 파일 세팅
+      - name: YML 파일 세팅 및 fcm.json 주입
         env:
           APPLICATION_PROPERTIES: ${{ secrets.APPLICATION_PROPERTIES }}
           TEST_APPLICATION_PROPERTIES: ${{ secrets.TEST_APPLICATION_PROPERTIES }}
           ERROR_MESSAGES_PROPERTIES: ${{ secrets.ERROR_MESSAGES_PROPERTIES }}
+          FCM_JSON: ${{secrets.FCM_JSON}}
         run: |
           cd ./src
           rm -rf main/resources/application.yml
           mkdir -p test/resources
           mkdir -p main/resources
+          mkdir -p main/resources/firebase
           echo "$APPLICATION_PROPERTIES" > main/resources/application.yml
           echo "$ERROR_MESSAGES_PROPERTIES" > main/resources/api-error-messages.properties
-          # echo "$TEST_APPLICATION_PROPERTIES" > test/resources/application.yml
+          echo "$FCM_JSON" > main/resources/firebase/fcm.json
+          echo "$TEST_APPLICATION_PROPERTIES" > test/resources/application.yml
 
       - name: gradlew 권한 부여
         run: chmod +x gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ src/test/resources/application-test.yml
 .env
 
 api-error-messages.properties
+.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,12 @@ dependencies {
     // aws
     implementation("software.amazon.awssdk:s3:2.30.38")
 
+    //okhttp3
+    implementation("com.squareup.okhttp3:okhttp:4.9.3")
+
+    //google auth
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.18.0")
+
     implementation("org.springframework.boot:spring-boot-starter-validation")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.0.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,10 +71,10 @@ dependencies {
     implementation("software.amazon.awssdk:s3:2.30.38")
 
     //okhttp3
-    implementation("com.squareup.okhttp3:okhttp:4.9.3")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
     //google auth
-    implementation("com.google.auth:google-auth-library-oauth2-http:1.18.0")
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.33.1")
 
     implementation("org.springframework.boot:spring-boot-starter-validation")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/gomushin/backend/BackendApplication.kt
+++ b/src/main/kotlin/gomushin/backend/BackendApplication.kt
@@ -3,9 +3,11 @@ package gomushin.backend
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@EnableAsync
 class BackendApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/gomushin/backend/alarm/dto/FCMMessage.kt
+++ b/src/main/kotlin/gomushin/backend/alarm/dto/FCMMessage.kt
@@ -1,0 +1,17 @@
+package gomushin.backend.alarm.dto
+
+data class FCMMessage(
+    val validateOnly: Boolean,
+    val message: Message
+) {
+    data class Message(
+        val notification: Notification,
+        val token: String
+    )
+
+    data class Notification(
+        val title: String,
+        val body: String,
+        val image: String?
+    )
+}

--- a/src/main/kotlin/gomushin/backend/alarm/service/FCMService.kt
+++ b/src/main/kotlin/gomushin/backend/alarm/service/FCMService.kt
@@ -77,7 +77,8 @@ class FCMService(
             googleCredentials.refreshIfExpired()
             return googleCredentials.accessToken.tokenValue
         } catch (e: IOException) {
-            throw BadRequestException(e.message.toString())
+            log.error("FCM AccessToken 발급 중 오류 발생", e)
+            throw BadRequestException("sarangggun.alarm.fail-issue-accesstoken")
         }
     }
 }

--- a/src/main/kotlin/gomushin/backend/alarm/service/FCMService.kt
+++ b/src/main/kotlin/gomushin/backend/alarm/service/FCMService.kt
@@ -1,0 +1,81 @@
+package gomushin.backend.alarm.service
+
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.auth.oauth2.GoogleCredentials
+import gomushin.backend.alarm.dto.FCMMessage
+import gomushin.backend.core.infrastructure.exception.BadRequestException
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.io.ClassPathResource
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Service
+import java.io.IOException
+
+@Service
+class FCMService(
+    private val objectMapper: ObjectMapper,
+    @Value("\${fcm.api-url}")
+    private val API_URL : String,
+    @Value("\${fcm.firebase-config-path}")
+    private val firebaseConfigPath : String,
+    @Value("\${fcm.google.scope}")
+    private val googleScope : String
+) {
+    private val log: Logger = LoggerFactory.getLogger(FCMService::class.java)
+    @Throws(IOException::class)
+    fun sendMessageTo(targetToken: String, title: String, body: String) {
+        val message = makeMessage(targetToken, title, body)
+
+        val client = OkHttpClient()
+        val requestBody = message
+            .toRequestBody("application/json; charset=utf-8".toMediaType())
+
+        val request = Request.Builder()
+            .url(API_URL)
+            .post(requestBody)
+            .addHeader(HttpHeaders.AUTHORIZATION, "Bearer ${getAccessToken()}")
+            .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            log.info("fcm 결과 : " + response.body?.string())
+        }
+    }
+
+    @Throws(JsonProcessingException::class)
+    private fun makeMessage(targetToken: String, title: String, body: String): String {
+        val fcmMessage = FCMMessage(
+            validateOnly = false,
+            message = FCMMessage.Message(
+                token = targetToken,
+                notification = FCMMessage.Notification(
+                    title = title,
+                    body = body,
+                    image = null
+                )
+            )
+        )
+        return objectMapper.writeValueAsString(fcmMessage)
+    }
+
+    @Throws(IOException::class)
+    private fun getAccessToken(): String {
+        try {
+            val googleCredentials = GoogleCredentials
+                .fromStream(ClassPathResource(firebaseConfigPath).inputStream)
+                .createScoped(listOf(googleScope))
+
+            googleCredentials.refreshIfExpired()
+            return googleCredentials.accessToken.tokenValue
+        } catch (e: IOException) {
+            throw BadRequestException(e.message.toString())
+        }
+    }
+}

--- a/src/main/kotlin/gomushin/backend/alarm/service/FCMService.kt
+++ b/src/main/kotlin/gomushin/backend/alarm/service/FCMService.kt
@@ -29,11 +29,13 @@ class FCMService(
     private val googleScope : String
 ) {
     private val log: Logger = LoggerFactory.getLogger(FCMService::class.java)
+    companion object {
+        private val client: OkHttpClient = OkHttpClient()
+    }
     @Throws(IOException::class)
     fun sendMessageTo(targetToken: String, title: String, body: String) {
         val message = makeMessage(targetToken, title, body)
 
-        val client = OkHttpClient()
         val requestBody = message
             .toRequestBody("application/json; charset=utf-8".toMediaType())
 

--- a/src/main/kotlin/gomushin/backend/alarm/service/StatusAlarmService.kt
+++ b/src/main/kotlin/gomushin/backend/alarm/service/StatusAlarmService.kt
@@ -1,6 +1,8 @@
 package gomushin.backend.alarm.service
 
+import gomushin.backend.core.infrastructure.exception.BadRequestException
 import gomushin.backend.member.domain.entity.Member
+import gomushin.backend.member.value.Emotion
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 
@@ -8,49 +10,42 @@ import org.springframework.stereotype.Service
 class StatusAlarmService (
     private val fcmService: FCMService
 ) {
-    private val dummyList = listOf<String>()
-    private val emojiMiss = listOf(
-        "보고싶다는 마음이 도착했어요.+오늘은 짧은 안부라도 건네볼까요?",
-        "보고 싶다고 표현하는 건 용기예요.+작은 마음이 큰 위로가 될 거예요")
-    private val emojiTired = listOf(
-        "오늘 많이 힘들었나봐요.+따뜻한 말 한마디가 큰 힘이 돼요",
-        "오늘 피곤한 날이래요.+연인에게 따뜻한 응원 어때요?"
-    )
-    private val emojiSad = listOf(
-        "서운한 마음이 들었대요.+연인과 진심 어린 대화 어때요?",
-        "연인의 마음이 무거운가봐요.+따뜻한 공감이 필요해요"
-    )
-    private val emojiGood = listOf(
-        "기분 좋은 하루를 함께 나눠보세요.+당신의 행복이 전해질 거예요.",
-        "좋은 일이 있었대요!+축하해주고 같이 기뻐해주세요\uD83D\uDC9B"
-    )
-    private val emojiAnnoy = listOf(
-        "연인이 짜증나는 일이 있었대요.+들어주는 것도 큰 위로가 될거예요",
-        "OO님 오늘 좀 힘들었나 봐요.+오늘 전화통화 어때요?"
-    )
-    private val emojiWorry = listOf(
-        "당신을 걱정하는 마음이 담겼어요.+잠깐 안부를 전해주면 어떨까요?",
-        "연인이 당신을 걱정해요.+연인의 마음 한쪽이 조금 무거웠대요."
-    )
-    private val emojiNothing = listOf(
-        "연인이 평범한 일상을 보냈대요.+안부를 전하는 일상이 관계를 지켜줄 거예요.",
-        "감정의 큰 파도는 없지만,+OO님의 하루를 들어줄 누군가가 있다면 좋겠대요."
-    )
-    private val statusMessage = listOf(
-        dummyList,
-        emojiMiss,
-        emojiTired,
-        emojiSad,
-        emojiGood,
-        emojiAnnoy,
-        emojiWorry,
-        emojiNothing
+    private val statusMessage: Map<Emotion, List<String>> = mapOf(
+        Emotion.MISS to listOf(
+            "보고싶다는 마음이 도착했어요.+오늘은 짧은 안부라도 건네볼까요?",
+            "보고 싶다고 표현하는 건 용기예요.+작은 마음이 큰 위로가 될 거예요"
+        ),
+        Emotion.TIRED to listOf(
+            "오늘 많이 힘들었나봐요.+따뜻한 말 한마디가 큰 힘이 돼요",
+            "오늘 피곤한 날이래요.+연인에게 따뜻한 응원 어때요?"
+        ),
+        Emotion.SAD to listOf(
+            "서운한 마음이 들었대요.+연인과 진심 어린 대화 어때요?",
+            "연인의 마음이 무거운가봐요.+따뜻한 공감이 필요해요"
+        ),
+        Emotion.GOOD to listOf(
+            "기분 좋은 하루를 함께 나눠보세요.+당신의 행복이 전해질 거예요.",
+            "좋은 일이 있었대요!+축하해주고 같이 기뻐해주세요💛"
+        ),
+        Emotion.ANNOY to listOf(
+            "연인이 짜증나는 일이 있었대요.+들어주는 것도 큰 위로가 될거예요",
+            "OO님 오늘 좀 힘들었나 봐요.+오늘 전화통화 어때요?"
+        ),
+        Emotion.WORRY to listOf(
+            "당신을 걱정하는 마음이 담겼어요.+잠깐 안부를 전해주면 어떨까요?",
+            "연인이 당신을 걱정해요.+연인의 마음 한쪽이 조금 무거웠대요."
+        ),
+        Emotion.NOTHING to listOf(
+            "연인이 평범한 일상을 보냈대요.+안부를 전하는 일상이 관계를 지켜줄 거예요.",
+            "감정의 큰 파도는 없지만,+OO님의 하루를 들어줄 누군가가 있다면 좋겠대요."
+        )
     )
 
     @Async
-    fun sendStatusAlarm(sender : Member, receiver : Member, emoji : Int) {
+    fun sendStatusAlarm(sender : Member, receiver : Member, emotion : Emotion) {
         val notificationContent =
-            statusMessage.get(emoji).random()
+            statusMessage[emotion]?.random()
+                ?: throw BadRequestException("sarangggun.member.not-exist-emoji")
         val parts = notificationContent.split("+")
         val title = parts[0]
         val content = if (parts[1].contains("OO")) {

--- a/src/main/kotlin/gomushin/backend/alarm/service/StatusAlarmService.kt
+++ b/src/main/kotlin/gomushin/backend/alarm/service/StatusAlarmService.kt
@@ -1,0 +1,64 @@
+package gomushin.backend.alarm.service
+
+import gomushin.backend.member.domain.entity.Member
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+
+@Service
+class StatusAlarmService (
+    private val fcmService: FCMService
+) {
+    private val dummyList = listOf<String>()
+    private val emojiMiss = listOf(
+        "보고싶다는 마음이 도착했어요.+오늘은 짧은 안부라도 건네볼까요?",
+        "보고 싶다고 표현하는 건 용기예요.+작은 마음이 큰 위로가 될 거예요")
+    private val emojiTired = listOf(
+        "오늘 많이 힘들었나봐요.+따뜻한 말 한마디가 큰 힘이 돼요",
+        "오늘 피곤한 날이래요.+연인에게 따뜻한 응원 어때요?"
+    )
+    private val emojiSad = listOf(
+        "서운한 마음이 들었대요.+연인과 진심 어린 대화 어때요?",
+        "연인의 마음이 무거운가봐요.+따뜻한 공감이 필요해요"
+    )
+    private val emojiGood = listOf(
+        "기분 좋은 하루를 함께 나눠보세요.+당신의 행복이 전해질 거예요.",
+        "좋은 일이 있었대요!+축하해주고 같이 기뻐해주세요\uD83D\uDC9B"
+    )
+    private val emojiAnnoy = listOf(
+        "연인이 짜증나는 일이 있었대요.+들어주는 것도 큰 위로가 될거예요",
+        "OO님 오늘 좀 힘들었나 봐요.+오늘 전화통화 어때요?"
+    )
+    private val emojiWorry = listOf(
+        "당신을 걱정하는 마음이 담겼어요.+잠깐 안부를 전해주면 어떨까요?",
+        "연인이 당신을 걱정해요.+연인의 마음 한쪽이 조금 무거웠대요."
+    )
+    private val emojiNothing = listOf(
+        "연인이 평범한 일상을 보냈대요.+안부를 전하는 일상이 관계를 지켜줄 거예요.",
+        "감정의 큰 파도는 없지만,+OO님의 하루를 들어줄 누군가가 있다면 좋겠대요."
+    )
+    private val statusMessage = listOf(
+        dummyList,
+        emojiMiss,
+        emojiTired,
+        emojiSad,
+        emojiGood,
+        emojiAnnoy,
+        emojiWorry,
+        emojiNothing
+    )
+
+    @Async
+    fun sendStatusAlarm(sender : Member, receiver : Member, emoji : Int) {
+        val notificationContent =
+            statusMessage.get(emoji).random()
+        val parts = notificationContent.split("+")
+        val title = parts[0]
+        val content = if (parts[1].contains("OO")) {
+            parts[1].replace("OO", sender.nickname)
+        } else {
+            parts[1]
+        }
+        val token = receiver.fcmToken
+        fcmService.sendMessageTo(token, title, content)
+    }
+}

--- a/src/main/kotlin/gomushin/backend/couple/domain/service/CoupleInfoService.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/service/CoupleInfoService.kt
@@ -91,7 +91,8 @@ class CoupleInfoService(
         return coupleMember.statusMessage
     }
 
-    private fun findCoupleMember(id : Long): Member {
+    @Transactional(readOnly = true)
+    fun findCoupleMember(id : Long): Member {
         val couple = coupleRepository.findByMemberId(id) ?: throw BadRequestException("saranggun.couple.not-connected")
         val coupleMemberId = if (couple.invitorId == id) couple.inviteeId else couple.invitorId
 

--- a/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
+++ b/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
@@ -26,7 +26,7 @@ class MemberService(
     }
 
     @Transactional
-    fun updateMyEmotionAndStatusMessage(id: Long, updateMyEmotionAndStatusMessageRequest: UpdateMyEmotionAndStatusMessageRequest){
+    fun updateMyEmotionAndStatusMessage(id: Long, updateMyEmotionAndStatusMessageRequest: UpdateMyEmotionAndStatusMessageRequest) {
         val member = getById(id)
         member.updateEmotion(updateMyEmotionAndStatusMessageRequest.emotion.code)
         member.updateStatusMessage(updateMyEmotionAndStatusMessageRequest.statusMessage)

--- a/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
+++ b/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
@@ -26,7 +26,7 @@ class MemberService(
     }
 
     @Transactional
-    fun updateMyEmotionAndStatusMessage(id: Long, updateMyEmotionAndStatusMessageRequest: UpdateMyEmotionAndStatusMessageRequest) {
+    fun updateMyEmotionAndStatusMessage(id: Long, updateMyEmotionAndStatusMessageRequest: UpdateMyEmotionAndStatusMessageRequest){
         val member = getById(id)
         member.updateEmotion(updateMyEmotionAndStatusMessageRequest.emotion)
         member.updateStatusMessage(updateMyEmotionAndStatusMessageRequest.statusMessage)

--- a/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
+++ b/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
@@ -28,7 +28,7 @@ class MemberService(
     @Transactional
     fun updateMyEmotionAndStatusMessage(id: Long, updateMyEmotionAndStatusMessageRequest: UpdateMyEmotionAndStatusMessageRequest){
         val member = getById(id)
-        member.updateEmotion(updateMyEmotionAndStatusMessageRequest.emotion)
+        member.updateEmotion(updateMyEmotionAndStatusMessageRequest.emotion.code)
         member.updateStatusMessage(updateMyEmotionAndStatusMessageRequest.statusMessage)
     }
 

--- a/src/main/kotlin/gomushin/backend/member/dto/request/UpdateMyEmotionAndStatusMessageRequest.kt
+++ b/src/main/kotlin/gomushin/backend/member/dto/request/UpdateMyEmotionAndStatusMessageRequest.kt
@@ -1,12 +1,13 @@
 package gomushin.backend.member.dto.request
 
+import gomushin.backend.member.value.Emotion
 import io.swagger.v3.oas.annotations.media.Schema
 
 
 data class UpdateMyEmotionAndStatusMessageRequest(
     @Schema(description = "이모지(1 : 보고싶어요, 2: 기분 좋아요, 3 : 아무느낌 없어요, " +
             "4 : 피곤해요, 5: 서운해요, 6 : 걱정돼요, 7 : 짜증나요)", example = "1")
-    val emotion : Int,
+    val emotion : Emotion,
 
     @Schema(description = "상태 메시지", example = "보고 싶어요")
     val statusMessage : String

--- a/src/main/kotlin/gomushin/backend/member/dto/request/UpdateMyEmotionAndStatusMessageRequest.kt
+++ b/src/main/kotlin/gomushin/backend/member/dto/request/UpdateMyEmotionAndStatusMessageRequest.kt
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 
 data class UpdateMyEmotionAndStatusMessageRequest(
-    @Schema(description = "이모지(1 : 보고싶어요, 2: 기분 좋아요, 3 : 아무느낌 없어요, " +
-            "4 : 피곤해요, 5: 서운해요, 6 : 걱정돼요, 7 : 짜증나요)", example = "1")
+    @Schema(description = "이모지(MISS : 보고싶어요, GOOD: 기분 좋아요, NOTHING : 아무느낌 없어요, " +
+            "TIRED : 피곤해요, SAD: 서운해요, WORRY : 걱정돼요, ANNOY : 짜증나요)", example = "1")
     val emotion : Emotion,
 
     @Schema(description = "상태 메시지", example = "보고 싶어요")

--- a/src/main/kotlin/gomushin/backend/member/value/Emotion.kt
+++ b/src/main/kotlin/gomushin/backend/member/value/Emotion.kt
@@ -1,0 +1,26 @@
+package gomushin.backend.member.value
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+import gomushin.backend.core.infrastructure.exception.BadRequestException
+
+enum class Emotion (val code: Int) {
+    MISS(1),
+    GOOD(2),
+    NOTHING(3),
+    TIRED(4),
+    SAD(5),
+    WORRY(6),
+    ANNOY(7);
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        fun from(code: Int): Emotion =
+            entries.find { it.code == code }
+                ?: throw BadRequestException("sarangggun.member.not-exist-emoji")
+    }
+
+    @JsonValue
+    fun toValue(): Int = code
+}

--- a/src/test/kotlin/gomushin/backend/member/domain/service/MemberServiceTest.kt
+++ b/src/test/kotlin/gomushin/backend/member/domain/service/MemberServiceTest.kt
@@ -7,6 +7,7 @@ import gomushin.backend.member.domain.value.Role
 import gomushin.backend.member.dto.request.UpdateMyBirthdayRequest
 import gomushin.backend.member.dto.request.UpdateMyEmotionAndStatusMessageRequest
 import gomushin.backend.member.dto.request.UpdateMyNickNameRequest
+import gomushin.backend.member.value.Emotion
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -68,12 +69,12 @@ class MemberServiceTest {
             emotion = 1,
             statusMessage = "상태 변경전"
         )
-        val updateMyEmotionAndStatusMessageRequest = UpdateMyEmotionAndStatusMessageRequest(2, "상태 변경후")
+        val updateMyEmotionAndStatusMessageRequest = UpdateMyEmotionAndStatusMessageRequest(Emotion.SAD, "상태 변경후")
         //when
         `when`(memberRepository.findById(memberId)).thenReturn(Optional.of(expectedMember))
         val result = memberService.updateMyEmotionAndStatusMessage(memberId, updateMyEmotionAndStatusMessageRequest)
         //then
-        assertEquals(expectedMember.emotion, updateMyEmotionAndStatusMessageRequest.emotion)
+        assertEquals(expectedMember.emotion, updateMyEmotionAndStatusMessageRequest.emotion.code)
         assertEquals(expectedMember.statusMessage, updateMyEmotionAndStatusMessageRequest.statusMessage)
     }
 

--- a/src/test/kotlin/gomushin/backend/member/facade/MemberInfoFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/member/facade/MemberInfoFacadeTest.kt
@@ -13,6 +13,7 @@ import gomushin.backend.member.dto.request.UpdateMyBirthdayRequest
 import gomushin.backend.member.dto.request.UpdateMyEmotionAndStatusMessageRequest
 import gomushin.backend.member.dto.request.UpdateMyNickNameRequest
 import gomushin.backend.member.dto.request.UpdateMyNotificationRequest
+import gomushin.backend.member.value.Emotion
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -118,7 +119,7 @@ class MemberInfoFacadeTest {
     @Test
     fun updateMyEmotionAndStatusMessage() {
         //given
-        val updateMyEmotionAndStatusMessageRequest = UpdateMyEmotionAndStatusMessageRequest(1, "좋은 날씨야")
+        val updateMyEmotionAndStatusMessageRequest = UpdateMyEmotionAndStatusMessageRequest(Emotion.GOOD, "좋은 날씨야")
         `when`(coupleInfoService.findCoupleMember(customUserDetails.getId())).thenReturn(memberCouple)
         `when`(notificationService.getByMemberId(memberCouple.id)).thenReturn(memberCoupleNotification)
         `when`(memberService.getById(customUserDetails.getId())).thenReturn(member)


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
#45 
- 사용자가 상태를 바꿀 때 상대 연인에게 해당 내용 푸시알림으로 가게 기능 구현
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 감정 및 상태 메시지 업데이트 시 상대방에게 FCM 푸시 알림이 전송됩니다.
  - 다양한 감정 상태별(이모지) 맞춤 메시지 템플릿이 추가되었습니다.
  - FCM 푸시 알림 전송을 위한 서비스가 도입되었습니다.
  - 감정 타입이 정수에서 강타입 이모지(enum)로 변경되어 명확성이 향상되었습니다.

- **개선 사항**
  - 감정 및 상태 메시지 변경 시 상대방의 알림 설정에 따라 알림이 조건부로 발송됩니다.
  - 비동기 방식의 알림 전송으로 앱 응답성이 향상되었습니다.
  - 커플 멤버 조회 기능이 외부에서 접근 가능하도록 변경되어 활용도가 높아졌습니다.
  - Google OAuth2 인증을 통한 FCM 메시지 전송 기능이 추가되었습니다.
  - 빌드 및 배포 과정에 Firebase 서비스 계정 설정이 자동화되었습니다.

- **버그 수정/테스트**
  - 커플 알림 및 상태 알림 기능에 대한 테스트가 추가되어 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->