### PR TITLE
Issue: (#58) 내 정보 반환 시 온보딩 여부도 함께 반환

### DIFF
--- a/src/main/kotlin/gomushin/backend/member/dto/response/MyInfoResponse.kt
+++ b/src/main/kotlin/gomushin/backend/member/dto/response/MyInfoResponse.kt
@@ -1,15 +1,21 @@
 package gomushin.backend.member.dto.response
 
 import gomushin.backend.member.domain.entity.Member
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class MyInfoResponse(
+    @Schema(description = "내 닉네임", example = "닉네임")
     val nickname: String,
+    @Schema(description = "커플 여부", example = "true")
     val isCouple: Boolean,
+    @Schema(description = "온보딩 여부 (GUEST : 온보딩 X , MEMBER : 온보딩 O)", example = "MEMBER")
+    val role: String
 ) {
     companion object {
         fun of(member: Member) = MyInfoResponse(
             member.nickname,
-            member.isCouple
+            member.isCouple,
+            member.role.name
         )
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 내 정보 반환 시 온보딩 여부도 보냄

---

## ✏️ 관련 이슈

- Resolves : #58 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 내 정보 응답에 회원의 온보딩 역할 정보를 추가하였습니다.

- **문서화**
  - API 응답 필드(nickname, isCouple, role)에 대한 설명과 예시가 문서에 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->