### PR TITLE
Issue: (#64) 디데이(기념일) 페이지네이션

### DIFF
--- a/src/main/kotlin/gomushin/backend/couple/domain/repository/AnniversaryRepository.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/repository/AnniversaryRepository.kt
@@ -89,4 +89,23 @@ interface AnniversaryRepository : JpaRepository<Anniversary, Long> {
     fun findTop3UpcomingAnniversaries(
         @Param("coupleId") coupleId: Long
     ): List<Anniversary>
+
+
+    @Query(
+        value =
+        """
+            SELECT * 
+            FROM anniversary a
+            WHERE a.couple_id = :coupleId
+                AND a.id < :key
+            ORDER BY anniversary_date DESC
+            LIMIT :take
+        """,
+        nativeQuery = true
+    )
+    fun findAnniversaries(
+        @Param("coupleId") coupleId: Long,
+        @Param("key") key: Long,
+        @Param("take") take: Long
+    ): List<Anniversary?>
 }

--- a/src/main/kotlin/gomushin/backend/couple/domain/service/AnniversaryService.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/service/AnniversaryService.kt
@@ -4,6 +4,7 @@ import gomushin.backend.couple.domain.entity.Anniversary
 import gomushin.backend.couple.domain.entity.Couple
 import gomushin.backend.couple.domain.repository.AnniversaryRepository
 import gomushin.backend.couple.dto.request.GenerateAnniversaryRequest
+import gomushin.backend.couple.dto.request.ReadAnniversariesRequest
 import gomushin.backend.couple.dto.response.MonthlyAnniversariesResponse
 import gomushin.backend.schedule.dto.response.DailyAnniversaryResponse
 import gomushin.backend.schedule.dto.response.MainAnniversariesResponse
@@ -17,7 +18,20 @@ class AnniversaryService(
 ) {
 
     @Transactional(readOnly = true)
-    fun findByCoupleIdAndDateBetween(couple: Couple, startDate: LocalDate, endDate: LocalDate): List<MainAnniversariesResponse> {
+    fun findAnniversaries(couple: Couple, readAnniversariesRequest: ReadAnniversariesRequest): List<Anniversary?> {
+        return anniversaryRepository.findAnniversaries(
+            couple.id,
+            readAnniversariesRequest.key,
+            readAnniversariesRequest.take,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun findByCoupleIdAndDateBetween(
+        couple: Couple,
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): List<MainAnniversariesResponse> {
         return anniversaryRepository.findByCoupleIdAndDateBetween(couple.id, startDate, endDate)
     }
 

--- a/src/main/kotlin/gomushin/backend/couple/dto/request/ReadAnniversariesRequest.kt
+++ b/src/main/kotlin/gomushin/backend/couple/dto/request/ReadAnniversariesRequest.kt
@@ -1,0 +1,7 @@
+package gomushin.backend.couple.dto.request
+
+data class ReadAnniversariesRequest(
+    val key: Long = Long.MAX_VALUE,
+    val orderCreatedAt: String = "DESC",
+    val take: Long = 10L,
+)

--- a/src/main/kotlin/gomushin/backend/couple/dto/response/TotalAnniversaryResponse.kt
+++ b/src/main/kotlin/gomushin/backend/couple/dto/response/TotalAnniversaryResponse.kt
@@ -1,0 +1,24 @@
+package gomushin.backend.couple.dto.response
+
+import gomushin.backend.couple.domain.entity.Anniversary
+import java.time.LocalDate
+
+data class TotalAnniversaryResponse(
+    val id: Long?,
+    val title: String?,
+    val anniversaryDate: LocalDate?,
+    val emoji: String?,
+) {
+    companion object {
+        fun of(
+            anniversary: Anniversary?
+        ): TotalAnniversaryResponse {
+            return TotalAnniversaryResponse(
+                id = anniversary?.id,
+                title = anniversary?.title,
+                anniversaryDate = anniversary?.anniversaryDate,
+                emoji = anniversary?.emoji.toString()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/gomushin/backend/couple/facade/AnniversaryFacade.kt
+++ b/src/main/kotlin/gomushin/backend/couple/facade/AnniversaryFacade.kt
@@ -34,7 +34,7 @@ class AnniversaryFacade(
         val hasData = anniversaryResponses.isNotEmpty()
 
         val nextUrl = if (!isLastPage && hasData) {
-            "${baseUrl}/v1/anniversaries?key=${anniversaryResponses.last().id}&take=${readAnniversariesRequest.take}&page=${readAnniversariesRequest.take}"
+            "${baseUrl}/v1/anniversaries?key=${anniversaryResponses.last().id}&take=${readAnniversariesRequest.take}"
         } else {
             null
         }

--- a/src/main/kotlin/gomushin/backend/couple/facade/AnniversaryFacade.kt
+++ b/src/main/kotlin/gomushin/backend/couple/facade/AnniversaryFacade.kt
@@ -1,16 +1,50 @@
 package gomushin.backend.couple.facade
 
 import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.core.common.web.PageResponse
 import gomushin.backend.couple.domain.service.AnniversaryService
+import gomushin.backend.couple.dto.request.ReadAnniversariesRequest
 import gomushin.backend.couple.dto.response.MainAnniversaryResponse
+import gomushin.backend.couple.dto.response.TotalAnniversaryResponse
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 @Component
 class AnniversaryFacade(
     private val anniversaryService: AnniversaryService,
+    @Value("\${server.url}")
+    private val baseUrl: String,
 ) {
     fun getAnniversaryListMain(customUserDetails: CustomUserDetails): List<MainAnniversaryResponse> {
         val anniversaries = anniversaryService.getUpcomingTop3Anniversaries(customUserDetails.getCouple())
         return anniversaries.map { MainAnniversaryResponse.of(it) }
+    }
+
+    fun getAnniversaryList(
+        customUserDetails: CustomUserDetails,
+        readAnniversariesRequest: ReadAnniversariesRequest,
+    ): PageResponse<TotalAnniversaryResponse> {
+        val anniversaries =
+            anniversaryService.findAnniversaries(customUserDetails.getCouple(), readAnniversariesRequest)
+        val anniversaryResponses = anniversaries.map { anniversary ->
+            TotalAnniversaryResponse.of(anniversary)
+        }
+        val isLastPage = anniversaryResponses.size < readAnniversariesRequest.take
+
+        val hasData = anniversaryResponses.isNotEmpty()
+
+        val nextUrl = if (!isLastPage && hasData) {
+            "${baseUrl}/v1/anniversaries?key=${anniversaryResponses.last().id}&take=${readAnniversariesRequest.take}&page=${readAnniversariesRequest.take}"
+        } else {
+            null
+        }
+
+        return PageResponse.of(
+            data = anniversaryResponses,
+            after = if (hasData) anniversaryResponses.last().id else null,
+            count = anniversaryResponses.size,
+            next = nextUrl,
+            isLastPage = isLastPage
+        )
     }
 }

--- a/src/main/kotlin/gomushin/backend/couple/presentation/AnniversaryController.kt
+++ b/src/main/kotlin/gomushin/backend/couple/presentation/AnniversaryController.kt
@@ -1,13 +1,17 @@
 package gomushin.backend.couple.presentation
 
 import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.core.common.web.PageResponse
 import gomushin.backend.core.common.web.response.ApiResponse
 import gomushin.backend.couple.dto.request.GenerateAnniversaryRequest
+import gomushin.backend.couple.dto.request.ReadAnniversariesRequest
 import gomushin.backend.couple.dto.response.MainAnniversaryResponse
+import gomushin.backend.couple.dto.response.TotalAnniversaryResponse
 import gomushin.backend.couple.facade.AnniversaryFacade
 import gomushin.backend.couple.facade.CoupleFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
@@ -42,4 +46,18 @@ class AnniversaryController(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails
     ): ApiResponse<List<MainAnniversaryResponse>> =
         ApiResponse.success(anniversaryFacade.getAnniversaryListMain(customUserDetails))
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping(ApiPath.ANNIVERSARIES)
+    @Operation(
+        summary = "기념일 리스트 조회",
+        description = "getAnniversaries"
+    )
+    fun getAnniversaryList(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @ParameterObject readAnniversariesRequest: ReadAnniversariesRequest,
+    ): PageResponse<TotalAnniversaryResponse> {
+        val anniversaries = anniversaryFacade.getAnniversaryList(customUserDetails, readAnniversariesRequest)
+        return anniversaries
+    }
 }

--- a/src/main/kotlin/gomushin/backend/couple/presentation/ApiPath.kt
+++ b/src/main/kotlin/gomushin/backend/couple/presentation/ApiPath.kt
@@ -15,4 +15,5 @@ object ApiPath {
     const val COUPLE_EMOJI = "/v1/couple/emotion"
     const val ANNIVERSARY_GENERATE = "/v1/couple/new-anniversary"
     const val ANNIVERSARY_MAIN = "/v1/anniversary/main"
+    const val ANNIVERSARIES = "/v1/anniversaries"
 }

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
@@ -48,9 +48,9 @@ class ReadLetterController(
     fun getLetterListToMe(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
         @ParameterObject readLettersToMePaginationRequest: ReadLettersToMePaginationRequest
-    ): ApiResponse<PageResponse<LetterPreviewResponse>> {
-        val letters = readLetterFacade.getLetterListToMe(customUserDetails,readLettersToMePaginationRequest)
-        return ApiResponse.success(letters)
+    ): PageResponse<LetterPreviewResponse> {
+        val letters = readLetterFacade.getLetterListToMe(customUserDetails, readLettersToMePaginationRequest)
+        return letters
     }
 
     @GetMapping(ApiPath.LETTERS_MAIN)


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 디데이(기념일) 페이지네이션

---

## ✏️ 관련 이슈

- Resolves : #64 


---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 기념일 목록을 페이지네이션 방식으로 조회할 수 있는 새로운 GET 엔드포인트가 추가되었습니다.
    - 기념일 목록 조회 시 커서 기반 페이지네이션, 정렬, 조회 개수 지정이 가능합니다.
    - 기념일 응답에 id, 제목, 날짜, 이모지 정보가 포함됩니다.

- **기존 기능 개선**
    - 내게 온 편지 목록 조회 API의 응답 포맷이 변경되어, 데이터를 더 직접적으로 받을 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->