### PR TITLE
Issue: (#75) 일정 응답 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Sarang Backend CI/CD
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   ci:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Sarang Backend CI/CD
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   ci:

--- a/src/main/kotlin/gomushin/backend/core/common/web/PageResponse.kt
+++ b/src/main/kotlin/gomushin/backend/core/common/web/PageResponse.kt
@@ -9,8 +9,8 @@ data class PageResponse<T>(
     val after: Long?,
     @Schema(description = "데이터 수")
     val count: Int,
-    @Schema(description = "다음 페이지 URL")
-    val next: String?,
+//    @Schema(description = "다음 페이지 URL")
+//    val next: String?,
     @Schema(description = "마지막 페이지 여부")
     val isLastPage: Boolean,
 ) {
@@ -19,14 +19,14 @@ data class PageResponse<T>(
             data: List<T>,
             after: Long?,
             count: Int,
-            next: String?,
+//            next: String?,
             isLastPage: Boolean,
         ): PageResponse<T> {
             return PageResponse(
                 data = data,
                 after = after,
                 count = count,
-                next = next,
+//                next = next,
                 isLastPage = isLastPage
             )
         }

--- a/src/main/kotlin/gomushin/backend/couple/domain/repository/AnniversaryRepository.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/repository/AnniversaryRepository.kt
@@ -46,6 +46,7 @@ interface AnniversaryRepository : JpaRepository<Anniversary, Long> {
         SELECT new gomushin.backend.schedule.dto.response.DailyAnniversaryResponse(
             a.id, 
             a.title, 
+            a.emoji,
             a.anniversaryDate
         )
         FROM Anniversary a

--- a/src/main/kotlin/gomushin/backend/couple/facade/AnniversaryFacade.kt
+++ b/src/main/kotlin/gomushin/backend/couple/facade/AnniversaryFacade.kt
@@ -33,17 +33,17 @@ class AnniversaryFacade(
 
         val hasData = anniversaryResponses.isNotEmpty()
 
-        val nextUrl = if (!isLastPage && hasData) {
-            "${baseUrl}/v1/anniversaries?key=${anniversaryResponses.last().id}&take=${readAnniversariesRequest.take}"
-        } else {
-            null
-        }
+//        val nextUrl = if (!isLastPage && hasData) {
+//            "${baseUrl}/v1/anniversaries?key=${anniversaryResponses.last().id}&take=${readAnniversariesRequest.take}"
+//        } else {
+//            null
+//        }
 
         return PageResponse.of(
             data = anniversaryResponses,
             after = if (hasData) anniversaryResponses.last().id else null,
             count = anniversaryResponses.size,
-            next = nextUrl,
+//            next = nextUrl,
             isLastPage = isLastPage
         )
     }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface LetterRepository : JpaRepository<Letter, Long> {
+    fun findByCoupleId(coupleId: Long): List<Letter>
+
     fun findByCoupleIdAndScheduleId(coupleId: Long, scheduleId: Long): List<Letter>
 
     fun findByCoupleIdAndScheduleIdAndId(coupleId: Long, scheduleId: Long, letterId: Long): Letter?

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
@@ -53,7 +53,7 @@ class LetterService(
 
     @Transactional(readOnly = true)
     fun findByCoupleIdAndScheduleIdAndId(couple: Couple, scheduleId: Long, letterId: Long) =
-        letterRepository.findByCoupleIdAndScheduleIdAndId(couple.id, letterId, scheduleId)
+        letterRepository.findByCoupleIdAndScheduleIdAndId(couple.id, scheduleId, letterId)
 
     @Transactional(readOnly = true)
     fun findByCoupleAndSchedule(couple: Couple, schedule: Schedule) =

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
@@ -42,6 +42,8 @@ class LetterService(
     @Transactional(readOnly = true)
     fun findById(id: Long) = letterRepository.findByIdOrNull(id)
 
+    @Transactional(readOnly = true)
+    fun findByCouple(couple: Couple) = letterRepository.findByCoupleId(couple.id)
 
     @Transactional(readOnly = true)
     fun getByCoupleAndScheduleAndId(

--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/DailyAnniversaryResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/DailyAnniversaryResponse.kt
@@ -1,9 +1,11 @@
 package gomushin.backend.schedule.dto.response
 
+import gomushin.backend.couple.domain.value.AnniversaryEmoji
 import java.time.LocalDate
 
 data class DailyAnniversaryResponse(
     val id: Long,
     val title: String,
+    val emoji: AnniversaryEmoji,
     val anniversaryDate: LocalDate,
 )

--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterPreviewResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterPreviewResponse.kt
@@ -2,10 +2,12 @@ package gomushin.backend.schedule.dto.response
 
 import gomushin.backend.schedule.domain.entity.Letter
 import gomushin.backend.schedule.domain.entity.Picture
+import gomushin.backend.schedule.domain.entity.Schedule
 import java.time.LocalDateTime
 
 data class LetterPreviewResponse(
     val letterId: Long?,
+    val scheduleTitle: String?,
     val title: String?,
     val content: String?,
     val pictureUrl: String?,
@@ -17,6 +19,7 @@ data class LetterPreviewResponse(
 
         fun of(
             letter: Letter?,
+            schedule: Schedule?,
             picture: Picture?
         ): LetterPreviewResponse {
             val previewContent = if (letter?.content != null && letter.content.length > MAX_CONTENT_LENGTH) {
@@ -26,6 +29,7 @@ data class LetterPreviewResponse(
             }
             return LetterPreviewResponse(
                 letterId = letter?.id,
+                scheduleTitle = schedule?.title,
                 title = letter?.title,
                 content = previewContent,
                 pictureUrl = picture?.pictureUrl,

--- a/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
@@ -68,23 +68,16 @@ class ReadLetterFacade(
         )
     }
 
-    fun getLetterListToMe(
+    fun getLetterListToCouple(
         customUserDetails: CustomUserDetails,
         readLettersToMePaginationRequest: ReadLettersToMePaginationRequest,
     ): PageResponse<LetterPreviewResponse> {
 
-        val partnerPk = if (customUserDetails.getCouple().invitorId == customUserDetails.getId()) {
-            customUserDetails.getCouple().inviteeId
-        } else {
-            customUserDetails.getCouple().invitorId
-        }
-
-        val letters =
-            letterService.findArrivedToMe(customUserDetails.getCouple(), partnerPk, readLettersToMePaginationRequest)
+        val letters = letterService.findByCouple(customUserDetails.getCouple())
 
         val letterPreviewResponses = letters.map { letter ->
-            val picture = letter?.let { pictureService.findFirstByLetterId(it.id) }
-            val schedule = letter?.let { scheduleService.getById(it.scheduleId) }
+            val picture = letter.let { pictureService.findFirstByLetterId(it.id) }
+            val schedule = letter.let { scheduleService.getById(it.scheduleId) }
             LetterPreviewResponse.of(letter, schedule, picture)
         }
 

--- a/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
@@ -33,7 +33,7 @@ class ReadLetterFacade(
         )
         return letters.map { letter ->
             val picture = pictureService.findFirstByLetterId(letter.id)
-            LetterPreviewResponse.of(letter, picture)
+            LetterPreviewResponse.of(letter, schedule, picture)
         }
     }
 
@@ -79,11 +79,13 @@ class ReadLetterFacade(
             customUserDetails.getCouple().invitorId
         }
 
-        val letters = letterService.findArrivedToMe(customUserDetails.getCouple(), partnerPk, readLettersToMePaginationRequest)
+        val letters =
+            letterService.findArrivedToMe(customUserDetails.getCouple(), partnerPk, readLettersToMePaginationRequest)
 
         val letterPreviewResponses = letters.map { letter ->
             val picture = letter?.let { pictureService.findFirstByLetterId(it.id) }
-            LetterPreviewResponse.of(letter, picture)
+            val schedule = letter?.let { scheduleService.getById(it.scheduleId) }
+            LetterPreviewResponse.of(letter, schedule, picture)
         }
 
         val isLastPage = letterPreviewResponses.size < readLettersToMePaginationRequest.take

--- a/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
@@ -48,6 +48,10 @@ class ReadLetterFacade(
             schedule,
             letterId,
         )
+
+        println("schedule = $schedule")
+        println("letter = $letter")
+
         val letterResponse = LetterResponse.of(letter)
 
         val pictures = pictureService.findAllByLetter(letter)

--- a/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
@@ -49,9 +49,6 @@ class ReadLetterFacade(
             letterId,
         )
 
-        println("schedule = $schedule")
-        println("letter = $letter")
-
         val letterResponse = LetterResponse.of(letter)
 
         val pictures = pictureService.findAllByLetter(letter)

--- a/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
@@ -89,17 +89,17 @@ class ReadLetterFacade(
 
         val hasData = letterPreviewResponses.isNotEmpty()
 
-        val nextUrl = if (!isLastPage && hasData) {
-            "${baseUrl}/v1/schedules/letters/to-me?key=${letterPreviewResponses.last().letterId}&orderCreatedAt=DESC&take=${readLettersToMePaginationRequest.take}"
-        } else {
-            null
-        }
+//        val nextUrl = if (!isLastPage && hasData) {
+//            "${baseUrl}/v1/schedules/letters/to-me?key=${letterPreviewResponses.last().letterId}&orderCreatedAt=DESC&take=${readLettersToMePaginationRequest.take}"
+//        } else {
+//            null
+//        }
 
         return PageResponse.of(
             data = letterPreviewResponses,
             after = if (hasData) letterPreviewResponses.last().letterId else null,
             count = letterPreviewResponses.size,
-            next = nextUrl,
+//            next = nextUrl,
             isLastPage = isLastPage
         )
     }

--- a/src/main/kotlin/gomushin/backend/schedule/facade/ReadScheduleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/ReadScheduleFacade.kt
@@ -41,7 +41,7 @@ class ReadScheduleFacade(
         val picturesByLetterId = pictureService.findAllByLetterIds(letterIds)
             .associateBy { it.letterId }
         val letterPreviews = letters.map { letter ->
-            LetterPreviewResponse.of(letter, picturesByLetterId[letter.id])
+            LetterPreviewResponse.of(letter, schedule, picturesByLetterId[letter.id])
         }
         return ScheduleDetailResponse.of(schedule, letterPreviews)
     }

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
@@ -39,6 +39,8 @@ class ReadLetterController(
         @PathVariable scheduleId: Long,
         @PathVariable letterId: Long,
     ): ApiResponse<LetterDetailResponse> {
+        println("scheduleId = $scheduleId")
+        println("letterId = $letterId")
         val letter = readLetterFacade.get(customUserDetails, scheduleId, letterId)
         return ApiResponse.success(letter)
     }

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
@@ -43,13 +43,13 @@ class ReadLetterController(
         return ApiResponse.success(letter)
     }
 
-    @GetMapping(ApiPath.LETTERS_TO_ME)
-    @Operation(summary = "내가 받은 편지 리스트 가져오기", description = "getLetterListToMe")
+    @GetMapping(ApiPath.LETTERS)
+    @Operation(summary = "커플 전체 편지 리스트 가져오기", description = "getLetterListToMe")
     fun getLetterListToMe(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
         @ParameterObject readLettersToMePaginationRequest: ReadLettersToMePaginationRequest
     ): PageResponse<LetterPreviewResponse> {
-        val letters = readLetterFacade.getLetterListToMe(customUserDetails, readLettersToMePaginationRequest)
+        val letters = readLetterFacade.getLetterListToCouple(customUserDetails, readLettersToMePaginationRequest)
         return letters
     }
 

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
@@ -39,8 +39,6 @@ class ReadLetterController(
         @PathVariable scheduleId: Long,
         @PathVariable letterId: Long,
     ): ApiResponse<LetterDetailResponse> {
-        println("scheduleId = $scheduleId")
-        println("letterId = $letterId")
         val letter = readLetterFacade.get(customUserDetails, scheduleId, letterId)
         return ApiResponse.success(letter)
     }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 일정 응답 수정

---

## ✏️ 관련 이슈

- Resolves : #75
---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 기념일 응답(DailyAnniversaryResponse)에 이모지(emoji) 정보가 추가되어, 각 기념일에 대한 이모지 표시가 가능합니다.
    - 편지 미리보기 응답(LetterPreviewResponse)에 스케줄 제목(scheduleTitle)이 추가되어, 편지와 연관된 스케줄 정보를 확인할 수 있습니다.

- **버그 수정**
    - 페이지네이션 응답에서 더 이상 next URL이 제공되지 않습니다. (기념일/편지 목록 등)
    - 편지 조회 시 파라미터 순서 오류가 수정되어 정확한 데이터가 반환됩니다.

- **문서화**
    - API 응답에서 next 필드가 제거되어, 관련 문서와 스웨거(Swagger) 스키마가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->