### PR TITLE
Issue: (#78) AL_01 질문형 푸시알림 제약조건 추가

### DIFF
--- a/src/main/kotlin/gomushin/backend/alarm/service/QuestionAlarmService.kt
+++ b/src/main/kotlin/gomushin/backend/alarm/service/QuestionAlarmService.kt
@@ -28,14 +28,14 @@ class QuestionAlarmService (
 
     @Scheduled(cron = "0 0 19 * * *", zone = "Asia/Seoul")
     fun sendQuestionAlarms() {
-        val coupleMembers = memberService.getAllCoupledMember()
+        val coupleMembers = memberService.getAllCoupledMemberWithEnabledNotification()
         runBlocking {
             coupleMembers.map { member ->
                 async(Dispatchers.IO) {
                     try {
                         val notificationContent = questionMessages.random()
                         val (title, sendContent) = MessageParsingUtil.parse(notificationContent)
-                        log.info("질문형 메시지 전송 : 수신자 {${member.name}}, 제목 {${title}}, 내용{${sendContent}}, 전송시각{${LocalDateTime.now()}}\n")
+                        log.info("질문형 메시지 전송 : 수신자 {${member.id}}, 제목 {${title}}, 내용{${sendContent}}, 전송시각{${LocalDateTime.now()}}\n")
                         fcmService.sendMessageTo(member.fcmToken, title, sendContent)
                     } catch (e: Exception) {
                         log.error("질문형 메시지 전송오류 : 수신자 {${member.name}}, 전송시각{${LocalDateTime.now()}}\n")

--- a/src/main/kotlin/gomushin/backend/member/domain/repository/MemberRepository.kt
+++ b/src/main/kotlin/gomushin/backend/member/domain/repository/MemberRepository.kt
@@ -6,6 +6,13 @@ import org.springframework.data.jpa.repository.Query
 
 interface MemberRepository : JpaRepository<Member, Long> {
     fun findByEmail(email: String): Member?
-    @Query("SELECT m FROM Member m WHERE m.isCouple = true")
-    fun findCoupledMembers(): List<Member>
+    @Query(
+        """
+    SELECT m FROM Member m
+    JOIN Notification n ON n.memberId = m.id
+    WHERE m.isCouple = true
+      AND NOT (n.dday = false AND n.partnerStatus = false)
+    """
+    )
+    fun findCoupleMembersWithEnabledNotification(): List<Member>
 }

--- a/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
+++ b/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
@@ -50,7 +50,7 @@ class MemberService(
     }
 
     @Transactional(readOnly = true)
-    fun getAllCoupledMember() : List<Member>{
-        return memberRepository.findCoupledMembers()
+    fun getAllCoupledMemberWithEnabledNotification() : List<Member>{
+        return memberRepository.findCoupleMembersWithEnabledNotification()
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
#78 
- 질문형 푸시알림 제약 조건 추가(notification 테이블에 있는 dday와 partner_status가 false인 member에게는 전송안되게)

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 알림이 활성화된 커플 회원에게만 질문 알림이 발송되도록 개선되었습니다.
  - 성공적으로 알림이 전송된 경우 회원 이름 대신 회원 ID가 로그에 기록됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->