### PR TITLE
Issue: (#81) 내게 온 편지 모아보기 응답에 스케쥴 ID 추가

### DIFF
--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
@@ -25,19 +25,17 @@ interface LetterRepository : JpaRepository<Letter, Long> {
             SELECT *
             FROM letter l 
             WHERE l.couple_id = :coupleId 
-                AND l.author_id = :partnerPk
                 AND l.id <:key
             ORDER BY l.created_at DESC         
             LIMIT :take
         """,
         nativeQuery = true
     )
-    fun findByLettersToMe(
+    fun findAllToCouple(
         @Param("coupleId") coupleId: Long,
-        @Param("partnerPk") partnerPk: Long,
         @Param("key") key: Long,
         @Param("take") take: Long,
-    ): List<Letter?>
+    ): List<Letter>
 
     fun findTop5ByCoupleIdOrderByCreatedAtDesc(coupleId: Long): List<Letter>
 }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
@@ -80,14 +80,12 @@ class LetterService(
     }
 
     @Transactional(readOnly = true)
-    fun findArrivedToMe(
+    fun findAllToCouple(
         couple: Couple,
-        partnerPk: Long,
         readLettersToMePaginationRequest: ReadLettersToMePaginationRequest
-    ): List<Letter?> {
-        return letterRepository.findByLettersToMe(
+    ): List<Letter> {
+        return letterRepository.findAllToCouple(
             couple.id,
-            partnerPk,
             readLettersToMePaginationRequest.key,
             readLettersToMePaginationRequest.take,
         )

--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterPreviewResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterPreviewResponse.kt
@@ -7,6 +7,7 @@ import java.time.LocalDateTime
 
 data class LetterPreviewResponse(
     val letterId: Long?,
+    val scheduleId: Long?,
     val scheduleTitle: String?,
     val title: String?,
     val content: String?,
@@ -29,6 +30,7 @@ data class LetterPreviewResponse(
             }
             return LetterPreviewResponse(
                 letterId = letter?.id,
+                scheduleId = schedule?.id,
                 scheduleTitle = schedule?.title,
                 title = letter?.title,
                 content = previewContent,

--- a/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
@@ -73,7 +73,7 @@ class ReadLetterFacade(
         readLettersToMePaginationRequest: ReadLettersToMePaginationRequest,
     ): PageResponse<LetterPreviewResponse> {
 
-        val letters = letterService.findByCouple(customUserDetails.getCouple())
+        val letters = letterService.findAllToCouple(customUserDetails.getCouple(), readLettersToMePaginationRequest)
 
         val letterPreviewResponses = letters.map { letter ->
             val picture = letter.let { pictureService.findFirstByLetterId(it.id) }

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/ApiPath.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/ApiPath.kt
@@ -9,7 +9,6 @@ object ApiPath {
 
     const val LETTERS = "/v1/schedules/letters"
     const val LETTER = "/v1/schedules/{scheduleId}/letters/{letterId}"
-    const val LETTERS_TO_ME = "/v1/schedules/letters/to-me"
     const val LETTERS_BY_SCHEDULE = "/v1/schedules/{scheduleId}"
     const val LETTERS_MAIN = "/v1/schedules/letters/main"
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 편지 모아보기 응답에 scheduleId 도 추가
- 잘못 사용한 페이지네이션 메서드 변경

---

## ✏️ 관련 이슈

- Resolves : #81
---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 편지 미리보기 응답에 일정 ID(scheduleId) 항목이 추가되었습니다.

- **기능 개선**
    - 커플에게 도착한 편지 목록 조회 시, 파트너별이 아닌 커플 전체 대상으로 조회하도록 변경되었습니다.
    - 편지 목록 조회 시 페이지네이션(페이징) 요청이 적용되어, 원하는 범위의 편지만 받아볼 수 있습니다.

- **기타**
    - 더 이상 사용되지 않는 API 경로 상수(LETTERS_TO_ME)가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->