### PR TITLE
Issue: (#49) 인증/인가 에러 커스텀

### DIFF
--- a/src/main/kotlin/gomushin/backend/core/configuration/jackson/JacksonConfig.kt
+++ b/src/main/kotlin/gomushin/backend/core/configuration/jackson/JacksonConfig.kt
@@ -1,6 +1,10 @@
 package gomushin.backend.core.configuration.jackson
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -8,7 +12,12 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class JacksonConfig {
     @Bean
-    fun objectMapper() : ObjectMapper {
-        return jacksonObjectMapper()
+    fun objectMapper(): ObjectMapper {
+        return jacksonObjectMapper().apply {
+            registerModules(JavaTimeModule())
+            registerModules(KotlinModule.Builder().build())
+            configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false)
+            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        }
     }
 }

--- a/src/main/kotlin/gomushin/backend/core/configuration/security/SecurityConfiguration.kt
+++ b/src/main/kotlin/gomushin/backend/core/configuration/security/SecurityConfiguration.kt
@@ -1,5 +1,6 @@
 package gomushin.backend.core.configuration.security
 
+import gomushin.backend.core.infrastructure.filter.CustomAuthenticationEntryPoint
 import gomushin.backend.core.infrastructure.filter.JwtAuthenticationFilter
 import gomushin.backend.core.jwt.JwtTokenProvider
 import gomushin.backend.core.oauth.handler.CustomAccessDeniedHandler
@@ -31,7 +32,8 @@ class SecurityConfiguration(
     fun filterChain(
         http: HttpSecurity, corsConfiguration: CustomCorsConfiguration,
         customOAuth2UserService: CustomOAuth2UserService, coupleRepository: CoupleRepository,
-        customAccessDeniedHandler: CustomAccessDeniedHandler
+        customAccessDeniedHandler: CustomAccessDeniedHandler,
+        customAuthenticationEntryPoint: CustomAuthenticationEntryPoint,
     ): SecurityFilterChain {
         http
             .csrf {
@@ -68,6 +70,7 @@ class SecurityConfiguration(
             }
             .exceptionHandling {
                 it.accessDeniedHandler(customAccessDeniedHandler)
+                it.authenticationEntryPoint(customAuthenticationEntryPoint)
             }
             .authorizeHttpRequests {
                 it.requestMatchers(

--- a/src/main/kotlin/gomushin/backend/core/infrastructure/filter/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/gomushin/backend/core/infrastructure/filter/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,37 @@
+package gomushin.backend.core.infrastructure.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import gomushin.backend.core.common.web.response.ExtendedHttpStatus
+import gomushin.backend.core.common.web.response.exception.ErrorCodeResolvingApiErrorException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+
+@Component
+class CustomAuthenticationEntryPoint: AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        authException: AuthenticationException?
+    ) {
+        if (response != null) {
+            if (response.isCommitted) return
+        }
+
+        response?.contentType = MediaType.APPLICATION_JSON_VALUE
+        response?.status = HttpServletResponse.SC_UNAUTHORIZED
+        response?.characterEncoding = "UTF-8"
+
+        val exception = ErrorCodeResolvingApiErrorException(
+            ExtendedHttpStatus.UNAUTHORIZED,
+            "sarangggun.auth.unauthorized"
+        )
+
+        response?.writer?.write(
+            ObjectMapper().writeValueAsString(exception.error)
+        )
+    }
+}

--- a/src/main/kotlin/gomushin/backend/core/infrastructure/filter/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/gomushin/backend/core/infrastructure/filter/CustomAuthenticationEntryPoint.kt
@@ -11,15 +11,14 @@ import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.stereotype.Component
 
 @Component
-class CustomAuthenticationEntryPoint: AuthenticationEntryPoint {
+class CustomAuthenticationEntryPoint(private val objectMapper: ObjectMapper): AuthenticationEntryPoint {
     override fun commence(
         request: HttpServletRequest?,
         response: HttpServletResponse?,
         authException: AuthenticationException?
     ) {
-        if (response != null) {
-            if (response.isCommitted) return
-        }
+
+        if(response?.isCommitted == true) return
 
         response?.contentType = MediaType.APPLICATION_JSON_VALUE
         response?.status = HttpServletResponse.SC_UNAUTHORIZED
@@ -31,7 +30,7 @@ class CustomAuthenticationEntryPoint: AuthenticationEntryPoint {
         )
 
         response?.writer?.write(
-            ObjectMapper().writeValueAsString(exception.error)
+            objectMapper.writeValueAsString(exception.error)
         )
     }
 }

--- a/src/main/kotlin/gomushin/backend/core/oauth/handler/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/gomushin/backend/core/oauth/handler/CustomAccessDeniedHandler.kt
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component
 
 
 @Component
-class CustomAccessDeniedHandler : AccessDeniedHandler {
+class CustomAccessDeniedHandler(private val objectMapper: ObjectMapper) : AccessDeniedHandler {
     override fun handle(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -25,23 +25,19 @@ class CustomAccessDeniedHandler : AccessDeniedHandler {
         response.characterEncoding = "UTF-8"
 
 
-        if (request.requestURI.contains("/v1/member/onboarding")) {
-            val exception = ErrorCodeResolvingApiErrorException(
-                ExtendedHttpStatus.FORBIDDEN,
-                "sarangggun.auth.guest-only"
-            )
-            response.writer.write(
-                ObjectMapper().writeValueAsString(exception.error)
-            )
+        val errorCode = if (request.requestURI.contains("/v1/member/onboarding")) {
+            "sarangggun.auth.guest-only"
         } else {
-            val exception = ErrorCodeResolvingApiErrorException(
-                ExtendedHttpStatus.FORBIDDEN,
-                "sarangggun.auth.member-only"
-            )
-            response.writer.write(
-                ObjectMapper().writeValueAsString(exception.error)
-            )
+            "sarangggun.auth.member-only"
         }
+
+        val exception = ErrorCodeResolvingApiErrorException(
+            ExtendedHttpStatus.FORBIDDEN,
+            errorCode
+        )
+        response.writer.write(
+            objectMapper.writeValueAsString(exception.error)
+        )
 
     }
 }

--- a/src/main/kotlin/gomushin/backend/core/oauth/handler/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/gomushin/backend/core/oauth/handler/CustomAccessDeniedHandler.kt
@@ -33,6 +33,14 @@ class CustomAccessDeniedHandler : AccessDeniedHandler {
             response.writer.write(
                 ObjectMapper().writeValueAsString(exception.error)
             )
+        } else {
+            val exception = ErrorCodeResolvingApiErrorException(
+                ExtendedHttpStatus.FORBIDDEN,
+                "sarangggun.auth.member-only"
+            )
+            response.writer.write(
+                ObjectMapper().writeValueAsString(exception.error)
+            )
         }
 
     }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 인증 / 인가 및 토큰 관련 에러 커스텀
- JacksonConfig 기초 모듈 추가

---

## ✏️ 관련 이슈

- Resolves : #49
---

## 🎸 기타 사항 or 추가 코멘트

- JacksonConfig 만들 때 날짜 관련 모듈을 추가 안해서 dto 역직렬화가 안되더라고 그래서 추가했어

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 인증되지 않은 요청에 대해 표준화된 JSON 에러 응답을 제공하는 인증 진입점이 추가되었습니다.

- **버그 수정**
    - 접근 거부 상황에서 모든 경우에 대해 JSON 에러 응답이 반환되도록 처리 로직이 개선되었습니다.

- **개선 사항**
    - JSON 직렬화 및 역직렬화 설정이 강화되어 날짜/시간 및 Kotlin 타입 지원이 향상되었습니다.
    - 인증 예외 처리 방식이 명확하게 분리되어, 인증 및 인가 오류에 대해 각각 구체적인 응답이 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->