### PR TITLE
Issue: (#88) 연속된 날짜의 일정 가져오기

### DIFF
--- a/src/main/kotlin/gomushin/backend/core/configuration/jackson/JacksonConfig.kt
+++ b/src/main/kotlin/gomushin/backend/core/configuration/jackson/JacksonConfig.kt
@@ -4,18 +4,40 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
 @Configuration
 class JacksonConfig {
+    companion object {
+        private const val DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss"
+        private const val DATE_FORMAT = "yyyy-MM-dd"
+        private const val TIME_FORMAT = "HH:mm:ss.SSS"
+        private val LOCAL_DATETIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT)
+        private val LOCAL_DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT)
+        private val LOCAL_TIME_FORMATTER = DateTimeFormatter.ofPattern(TIME_FORMAT)
+    }
+
     @Bean
     fun objectMapper(): ObjectMapper {
+        val javaTimeModule = JavaTimeModule().apply {
+            addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer(LOCAL_DATETIME_FORMATTER))
+            addSerializer(LocalDate::class.java, LocalDateSerializer(LOCAL_DATE_FORMATTER))
+            addSerializer(LocalTime::class.java, LocalTimeSerializer(LOCAL_TIME_FORMATTER))
+        }
+
         return jacksonObjectMapper().apply {
-            registerModules(JavaTimeModule())
-            registerModules(KotlinModule.Builder().build())
+            registerModules(javaTimeModule, KotlinModule.Builder().build())
+            configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false)
             configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/ScheduleRepository.kt
@@ -45,10 +45,10 @@ interface ScheduleRepository : JpaRepository<Schedule, Long> {
         )
         FROM Schedule s
         WHERE s.coupleId = :coupleId 
-        AND function('DATE', s.startDate) = :startDate
+        AND :date BETWEEN FUNCTION('DATE', s.startDate) AND FUNCTION('DATE', s.endDate)
     """
     )
-    fun findByCoupleIdAndStartDate(coupleId: Long, startDate: LocalDate): List<DailyScheduleResponse>
+    fun findByCoupleIdAndDate(coupleId: Long, date: LocalDate): List<DailyScheduleResponse>
 
     @Query(
         """
@@ -61,10 +61,11 @@ interface ScheduleRepository : JpaRepository<Schedule, Long> {
         )
         FROM Schedule s
         WHERE s.coupleId = :coupleId 
-        AND s.startDate BETWEEN :startDate AND :endDate
+        AND s.startDate <= :endDate 
+        AND s.endDate >= :startDate
     """
     )
-    fun findByCoupleIdAndStartDateBetween(
+    fun findByCoupleIdAndStartDateAndEndDateBetween(
         coupleId: Long,
         startDate: LocalDateTime,
         endDate: LocalDateTime

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/ScheduleService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/ScheduleService.kt
@@ -28,7 +28,7 @@ class ScheduleService(
         startDate: LocalDate,
         endDate: LocalDate
     ): List<MainSchedulesResponse> {
-        return scheduleRepository.findByCoupleIdAndStartDateBetween(
+        return scheduleRepository.findByCoupleIdAndStartDateAndEndDateBetween(
             couple.id,
             startDate.atStartOfDay(),
             endDate.atTime(23, 59, 59)
@@ -37,7 +37,7 @@ class ScheduleService(
 
     @Transactional(readOnly = true)
     fun findByDate(couple: Couple, date: LocalDate): List<DailyScheduleResponse> {
-        return scheduleRepository.findByCoupleIdAndStartDate(couple.id, date)
+        return scheduleRepository.findByCoupleIdAndDate(couple.id, date)
     }
 
     @Transactional


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 일정을 가져올 때 , 일정의 시작 날짜와 종료 날짜 사이에 겹쳐있는 일정이라면 모두 가져오기

---

## ✏️ 관련 이슈

- Resolves : #88 #69 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
    - 일정 조회 시 시작일뿐만 아니라 일정 기간 전체를 고려하여 조회하도록 개선되었습니다. 이제 지정한 날짜가 일정 기간 내에 포함될 경우 해당 일정이 조회됩니다.
- **리팩터**
    - 일정 조회 관련 메서드 명칭이 실제 동작을 더 잘 반영하도록 변경되었습니다.
- **스타일**
    - 날짜 및 시간 형식이 일관되게 포맷팅되어 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->