### PR TITLE
Issue: (#94) 페이지  기반 페이지네이션으로 수정

### DIFF
--- a/src/main/kotlin/gomushin/backend/core/common/web/PageResponse.kt
+++ b/src/main/kotlin/gomushin/backend/core/common/web/PageResponse.kt
@@ -1,34 +1,23 @@
 package gomushin.backend.core.common.web
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.data.domain.Page
 
 data class PageResponse<T>(
     @Schema(description = "페이지 응답")
-    val data: List<T>?,
-    @Schema(description = "다음 페이지를 위한 커서 키")
-    val after: Long?,
-    @Schema(description = "데이터 수")
-    val count: Int,
-//    @Schema(description = "다음 페이지 URL")
-//    val next: String?,
+    val data: List<T>,
+    @Schema(description = "전체 페이지 수")
+    val totalPages: Int,
     @Schema(description = "마지막 페이지 여부")
     val isLastPage: Boolean,
 ) {
     companion object {
-        fun <T> of(
-            data: List<T>,
-            after: Long?,
-            count: Int,
-//            next: String?,
-            isLastPage: Boolean,
-        ): PageResponse<T> {
-            return PageResponse(
-                data = data,
-                after = after,
-                count = count,
-//                next = next,
-                isLastPage = isLastPage
-            )
-        }
+        fun <T> from(
+            page: Page<T>
+        ): PageResponse<T> = PageResponse(
+            data = page.content,
+            totalPages = page.totalPages,
+            isLastPage = page.isLast
+        )
     }
 }

--- a/src/main/kotlin/gomushin/backend/couple/domain/repository/AnniversaryRepository.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/repository/AnniversaryRepository.kt
@@ -5,12 +5,13 @@ import gomushin.backend.couple.dto.response.AnniversaryNotificationInfo
 import gomushin.backend.couple.dto.response.MonthlyAnniversariesResponse
 import gomushin.backend.schedule.dto.response.DailyAnniversaryResponse
 import gomushin.backend.schedule.dto.response.MainAnniversariesResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 interface AnniversaryRepository : JpaRepository<Anniversary, Long> {
     @Modifying
@@ -94,22 +95,16 @@ interface AnniversaryRepository : JpaRepository<Anniversary, Long> {
 
 
     @Query(
-        value =
         """
-            SELECT * 
-            FROM anniversary a
-            WHERE a.couple_id = :coupleId
-                AND a.id < :key
-            ORDER BY anniversary_date DESC
-            LIMIT :take
-        """,
-        nativeQuery = true
+            SELECT a FROM Anniversary a
+            WHERE a.coupleId = :coupleId
+            ORDER BY a.anniversaryDate DESC
+        """
     )
     fun findAnniversaries(
         @Param("coupleId") coupleId: Long,
-        @Param("key") key: Long,
-        @Param("take") take: Long
-    ): List<Anniversary?>
+        pageable: Pageable
+    ): Page<Anniversary>
 
     @Query(
         """
@@ -123,5 +118,5 @@ interface AnniversaryRepository : JpaRepository<Anniversary, Long> {
     """,
         nativeQuery = true
     )
-    fun findTodayAnniversaryMemberFcmTokens(@Param("nowDate")date: LocalDate): List<AnniversaryNotificationInfo>
+    fun findTodayAnniversaryMemberFcmTokens(@Param("nowDate") date: LocalDate): List<AnniversaryNotificationInfo>
 }

--- a/src/main/kotlin/gomushin/backend/couple/domain/service/AnniversaryService.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/service/AnniversaryService.kt
@@ -4,11 +4,12 @@ import gomushin.backend.couple.domain.entity.Anniversary
 import gomushin.backend.couple.domain.entity.Couple
 import gomushin.backend.couple.domain.repository.AnniversaryRepository
 import gomushin.backend.couple.dto.request.GenerateAnniversaryRequest
-import gomushin.backend.couple.dto.request.ReadAnniversariesRequest
 import gomushin.backend.couple.dto.response.AnniversaryNotificationInfo
 import gomushin.backend.couple.dto.response.MonthlyAnniversariesResponse
 import gomushin.backend.schedule.dto.response.DailyAnniversaryResponse
 import gomushin.backend.schedule.dto.response.MainAnniversariesResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -19,11 +20,10 @@ class AnniversaryService(
 ) {
 
     @Transactional(readOnly = true)
-    fun findAnniversaries(couple: Couple, readAnniversariesRequest: ReadAnniversariesRequest): List<Anniversary?> {
+    fun findAnniversaries(couple: Couple, pageRequest: PageRequest): Page<Anniversary> {
         return anniversaryRepository.findAnniversaries(
             couple.id,
-            readAnniversariesRequest.key,
-            readAnniversariesRequest.take,
+            pageRequest
         )
     }
 
@@ -74,7 +74,7 @@ class AnniversaryService(
     }
 
     @Transactional(readOnly = true)
-    fun getTodayAnniversaryMemberFcmTokens(date : LocalDate) : List<AnniversaryNotificationInfo> {
+    fun getTodayAnniversaryMemberFcmTokens(date: LocalDate): List<AnniversaryNotificationInfo> {
         return anniversaryRepository.findTodayAnniversaryMemberFcmTokens(date)
     }
 }

--- a/src/main/kotlin/gomushin/backend/couple/facade/AnniversaryFacade.kt
+++ b/src/main/kotlin/gomushin/backend/couple/facade/AnniversaryFacade.kt
@@ -3,10 +3,10 @@ package gomushin.backend.couple.facade
 import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.core.common.web.PageResponse
 import gomushin.backend.couple.domain.service.AnniversaryService
-import gomushin.backend.couple.dto.request.ReadAnniversariesRequest
 import gomushin.backend.couple.dto.response.MainAnniversaryResponse
 import gomushin.backend.couple.dto.response.TotalAnniversaryResponse
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
 
 @Component
@@ -22,29 +22,16 @@ class AnniversaryFacade(
 
     fun getAnniversaryList(
         customUserDetails: CustomUserDetails,
-        readAnniversariesRequest: ReadAnniversariesRequest,
+        page: Int,
+        size: Int,
     ): PageResponse<TotalAnniversaryResponse> {
+        val pageRequest = PageRequest.of(page, size)
         val anniversaries =
-            anniversaryService.findAnniversaries(customUserDetails.getCouple(), readAnniversariesRequest)
+            anniversaryService.findAnniversaries(customUserDetails.getCouple(), pageRequest)
         val anniversaryResponses = anniversaries.map { anniversary ->
             TotalAnniversaryResponse.of(anniversary)
         }
-        val isLastPage = anniversaryResponses.size < readAnniversariesRequest.take
 
-        val hasData = anniversaryResponses.isNotEmpty()
-
-//        val nextUrl = if (!isLastPage && hasData) {
-//            "${baseUrl}/v1/anniversaries?key=${anniversaryResponses.last().id}&take=${readAnniversariesRequest.take}"
-//        } else {
-//            null
-//        }
-
-        return PageResponse.of(
-            data = anniversaryResponses,
-            after = if (hasData) anniversaryResponses.last().id else null,
-            count = anniversaryResponses.size,
-//            next = nextUrl,
-            isLastPage = isLastPage
-        )
+        return PageResponse.from(anniversaryResponses)
     }
 }

--- a/src/main/kotlin/gomushin/backend/couple/presentation/AnniversaryController.kt
+++ b/src/main/kotlin/gomushin/backend/couple/presentation/AnniversaryController.kt
@@ -4,14 +4,12 @@ import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.core.common.web.PageResponse
 import gomushin.backend.core.common.web.response.ApiResponse
 import gomushin.backend.couple.dto.request.GenerateAnniversaryRequest
-import gomushin.backend.couple.dto.request.ReadAnniversariesRequest
 import gomushin.backend.couple.dto.response.MainAnniversaryResponse
 import gomushin.backend.couple.dto.response.TotalAnniversaryResponse
 import gomushin.backend.couple.facade.AnniversaryFacade
 import gomushin.backend.couple.facade.CoupleFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
@@ -55,9 +53,10 @@ class AnniversaryController(
     )
     fun getAnniversaryList(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
-        @ParameterObject readAnniversariesRequest: ReadAnniversariesRequest,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
     ): PageResponse<TotalAnniversaryResponse> {
-        val anniversaries = anniversaryFacade.getAnniversaryList(customUserDetails, readAnniversariesRequest)
+        val anniversaries = anniversaryFacade.getAnniversaryList(customUserDetails, page, size)
         return anniversaries
     }
 }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/LetterRepository.kt
@@ -1,6 +1,8 @@
 package gomushin.backend.schedule.domain.repository
 
 import gomushin.backend.schedule.domain.entity.Letter
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -22,20 +24,15 @@ interface LetterRepository : JpaRepository<Letter, Long> {
 
     @Query(
         """
-            SELECT *
-            FROM letter l 
-            WHERE l.couple_id = :coupleId 
-                AND l.id <:key
-            ORDER BY l.created_at DESC         
-            LIMIT :take
+        SELECT l FROM Letter l
+        WHERE l.coupleId = :coupleId
+        ORDER BY l.createdAt DESC
         """,
-        nativeQuery = true
     )
     fun findAllToCouple(
         @Param("coupleId") coupleId: Long,
-        @Param("key") key: Long,
-        @Param("take") take: Long,
-    ): List<Letter>
+        pageable: Pageable
+    ): Page<Letter>
 
     fun findTop5ByCoupleIdOrderByCreatedAtDesc(coupleId: Long): List<Letter>
 }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
@@ -5,8 +5,9 @@ import gomushin.backend.couple.domain.entity.Couple
 import gomushin.backend.schedule.domain.entity.Letter
 import gomushin.backend.schedule.domain.entity.Schedule
 import gomushin.backend.schedule.domain.repository.LetterRepository
-import gomushin.backend.schedule.dto.request.ReadLettersToMePaginationRequest
 import gomushin.backend.schedule.dto.request.UpsertLetterRequest
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -82,12 +83,11 @@ class LetterService(
     @Transactional(readOnly = true)
     fun findAllToCouple(
         couple: Couple,
-        readLettersToMePaginationRequest: ReadLettersToMePaginationRequest
-    ): List<Letter> {
+        pageable: Pageable
+    ): Page<Letter> {
         return letterRepository.findAllToCouple(
             couple.id,
-            readLettersToMePaginationRequest.key,
-            readLettersToMePaginationRequest.take,
+            pageable
         )
     }
 

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
@@ -3,17 +3,16 @@ package gomushin.backend.schedule.presentation
 import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.core.common.web.PageResponse
 import gomushin.backend.core.common.web.response.ApiResponse
-import gomushin.backend.schedule.dto.request.ReadLettersToMePaginationRequest
 import gomushin.backend.schedule.dto.response.LetterDetailResponse
 import gomushin.backend.schedule.dto.response.LetterPreviewResponse
 import gomushin.backend.schedule.dto.response.MainLetterPreviewResponse
 import gomushin.backend.schedule.facade.ReadLetterFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springdoc.core.annotations.ParameterObject
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -47,9 +46,10 @@ class ReadLetterController(
     @Operation(summary = "커플 전체 편지 리스트 가져오기", description = "getLetterListToMe")
     fun getLetterListToMe(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
-        @ParameterObject readLettersToMePaginationRequest: ReadLettersToMePaginationRequest
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
     ): PageResponse<LetterPreviewResponse> {
-        val letters = readLetterFacade.getLetterListToCouple(customUserDetails, readLettersToMePaginationRequest)
+        val letters = readLetterFacade.getLetterListToCouple(customUserDetails, page, size);
         return letters
     }
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- key offset 에서 페이지 기반으로 페이지네이션 수정

![image](https://github.com/user-attachments/assets/157f5dc9-695f-4e93-ad23-64ca7d90792d)

---

## ✏️ 관련 이슈

- Resolves : #94
---

## 🎸 기타 사항 or 추가 코멘트



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 기념일 및 편지 목록 조회 시 페이지 기반의 표준화된 페이징 방식 적용 및 전체 페이지 수(totalPages) 제공.

- **Refactor**
    - 커서 기반 페이징에서 Spring Data의 페이지 기반 페이징으로 전환.
    - 모든 관련 API에서 커스텀 요청 객체 대신 page, size 파라미터로 페이징 처리 방식 변경.
    - 페이징 응답 구조를 간소화하여 불필요한 메타데이터 제거 및 일관성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->