### PR TITLE
Issue : (#97) 기념일 초기 설정 락 설정

### DIFF
--- a/src/main/kotlin/gomushin/backend/couple/domain/repository/CoupleRepository.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/repository/CoupleRepository.kt
@@ -1,14 +1,18 @@
 package gomushin.backend.couple.domain.repository
 
 import gomushin.backend.couple.domain.entity.Couple
+import jakarta.persistence.LockModeType
+import jakarta.persistence.QueryHint
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
 import org.springframework.data.repository.query.Param
 
 interface CoupleRepository : JpaRepository<Couple, Long> {
-    fun findByInvitorId(invitorId: Long) : Couple?
-    fun findByInviteeId(inviteeId: Long) : Couple?
+    fun findByInvitorId(invitorId: Long): Couple?
+    fun findByInviteeId(inviteeId: Long): Couple?
 
     @Query("SELECT c FROM Couple c WHERE c.invitorId = :memberId OR c.inviteeId = :memberId")
     fun findByMemberId(@Param("memberId") memberId: Long): Couple?
@@ -16,4 +20,9 @@ interface CoupleRepository : JpaRepository<Couple, Long> {
     @Modifying
     @Query("DELETE FROM Couple c WHERE c.invitorId = :memberId OR c.inviteeId = :memberId")
     fun deleteByMemberId(@Param("memberId") memberId: Long)
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(QueryHint(name = "javax.persistence.lock.timeout", value = "3000"))
+    @Query("SELECT c FROM Couple c WHERE c.id = :id")
+    fun findByIdWithLock(@Param("id") id: Long): Couple?
 }

--- a/src/main/kotlin/gomushin/backend/couple/domain/service/CoupleService.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/service/CoupleService.kt
@@ -17,6 +17,16 @@ class CoupleService(
     }
 
     @Transactional(readOnly = true)
+    fun getByIdWithLock(id: Long): Couple {
+        return findByIdWithLock(id) ?: throw BadRequestException("sarangggun.couple.not-found")
+    }
+
+    @Transactional(readOnly = true)
+    fun findByIdWithLock(id: Long): Couple? {
+        return coupleRepository.findByIdWithLock(id)
+    }
+
+    @Transactional(readOnly = true)
     fun findById(id: Long): Couple? {
         return coupleRepository.findByIdOrNull(id)
     }

--- a/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
@@ -45,7 +45,7 @@ class CoupleFacade(
         customUserDetails: CustomUserDetails,
         request: CoupleAnniversaryRequest
     ) {
-        val couple = coupleService.getById(request.coupleId)
+        val couple = coupleService.getByIdWithLock(request.coupleId)
         checkUserInCouple(customUserDetails.getId(), couple)
         checkCoupleAnniversaryIsInit(couple)
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 기념일 초기 설정 시 발생할 수 있는 동시성 문제를 해결하기 위해 비관적 락 적용

---

## ✏️ 관련 이슈

- Resolves : #97
---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 커플 정보를 조회할 때 데이터베이스 락을 적용하여 조회하는 기능이 추가되었습니다.

- **버그 수정**
    - 기념일 등록 시 커플 정보 조회에 락이 적용되어 동시성 문제가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->