### PR TITLE
Issue: (#103) 커플 편지 전체보기 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Sarang Backend CI/CD
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   ci:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Sarang Backend CI/CD
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   ci:

--- a/src/main/kotlin/gomushin/backend/core/oauth/handler/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/gomushin/backend/core/oauth/handler/CustomAccessDeniedHandler.kt
@@ -5,6 +5,7 @@ import gomushin.backend.core.common.web.response.ExtendedHttpStatus
 import gomushin.backend.core.common.web.response.exception.ErrorCodeResolvingApiErrorException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.web.access.AccessDeniedHandler
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class CustomAccessDeniedHandler(private val objectMapper: ObjectMapper) : AccessDeniedHandler {
+    private val logger = LoggerFactory.getLogger(CustomAccessDeniedHandler::class.java)
     override fun handle(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -24,6 +26,8 @@ class CustomAccessDeniedHandler(private val objectMapper: ObjectMapper) : Access
         response.status = HttpServletResponse.SC_FORBIDDEN
         response.characterEncoding = "UTF-8"
 
+        // 정확히 어떤 이유로 발생한 에러인지 보려면 어떻게 해야하나
+        logger.error("Access Denied: ${accessDeniedException.message}")
 
         val errorCode = if (request.requestURI.contains("/v1/member/onboarding")) {
             "sarangggun.auth.guest-only"

--- a/src/main/kotlin/gomushin/backend/couple/presentation/AnniversaryController.kt
+++ b/src/main/kotlin/gomushin/backend/couple/presentation/AnniversaryController.kt
@@ -53,10 +53,11 @@ class AnniversaryController(
     )
     fun getAnniversaryList(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
-        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
     ): PageResponse<TotalAnniversaryResponse> {
-        val anniversaries = anniversaryFacade.getAnniversaryList(customUserDetails, page, size)
+        val safePage = if (page < 1) 0 else page - 1
+        val anniversaries = anniversaryFacade.getAnniversaryList(customUserDetails, safePage, size)
         return anniversaries
     }
 }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/CommentRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/CommentRepository.kt
@@ -12,4 +12,8 @@ interface CommentRepository : JpaRepository<Comment, Long> {
     @Modifying
     @Query("DELETE FROM Comment c WHERE c.authorId = :authorId")
     fun deleteAllByAuthorId(@Param("authorId") authorId: Long)
+
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.letterId = :letterId")
+    fun deleteAllByLetterId(letterId: Long)
 }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/repository/PictureRepository.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/repository/PictureRepository.kt
@@ -8,9 +8,12 @@ import org.springframework.data.repository.query.Param
 
 interface PictureRepository : JpaRepository<Picture, Long> {
     fun findAllByPictureUrlIn(urls: List<String>): List<Picture>
-    fun deleteAllByLetterId(letterId: Long)
     fun findAllByLetterId(letterId: Long): List<Picture>
     fun findFirstByLetterIdOrderByIdAsc(letterId: Long): Picture?
+
+    @Modifying
+    @Query("DELETE FROM Picture p WHERE p.letterId = :letterId")
+    fun deleteAllByLetterId(letterId: Long)
 
     @Query("SELECT p FROM Picture p WHERE p.letterId IN :letterIds")
     fun findAllByLetterIdIn(@Param("letterIds") letterIds: List<Long>): List<Picture>

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/CommentService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/CommentService.kt
@@ -67,4 +67,9 @@ class CommentService(
     fun deleteAllByMemberId(memberId: Long) {
         commentRepository.deleteAllByAuthorId(memberId)
     }
+
+    @Transactional
+    fun deleteAllByLetterId(letterId: Long) {
+        commentRepository.deleteAllByLetterId(letterId)
+    }
 }

--- a/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/domain/service/LetterService.kt
@@ -38,6 +38,11 @@ class LetterService(
     }
 
     @Transactional(readOnly = true)
+    fun findByCoupleIdAndScheduleId(couple: Couple, scheduleId: Long): List<Letter> {
+        return letterRepository.findByCoupleIdAndScheduleId(couple.id, scheduleId)
+    }
+
+    @Transactional(readOnly = true)
     fun getById(id: Long) = findById(id) ?: throw BadRequestException("sarangggun.letter.not-exist")
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/MonthlySchedulesAndAnniversariesResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/MonthlySchedulesAndAnniversariesResponse.kt
@@ -4,14 +4,14 @@ import gomushin.backend.couple.dto.response.MonthlyAnniversariesResponse
 
 data class MonthlySchedulesAndAnniversariesResponse(
     val schedules: List<MonthlySchedulesResponse>,
-//    val anniversaries: List<MonthlyAnniversariesResponse>,
+    val anniversaries: List<MonthlyAnniversariesResponse>,
 ) {
     companion object {
         fun of(
             schedules: List<MonthlySchedulesResponse>,
             anniversaries: List<MonthlyAnniversariesResponse>,
         ): MonthlySchedulesAndAnniversariesResponse {
-            return MonthlySchedulesAndAnniversariesResponse(schedules)
+            return MonthlySchedulesAndAnniversariesResponse(schedules, anniversaries)
         }
     }
 }

--- a/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteScheduleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteScheduleFacade.kt
@@ -1,13 +1,22 @@
 package gomushin.backend.schedule.facade
 
 import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.core.service.S3Service
+import gomushin.backend.schedule.domain.service.CommentService
+import gomushin.backend.schedule.domain.service.LetterService
+import gomushin.backend.schedule.domain.service.PictureService
 import gomushin.backend.schedule.domain.service.ScheduleService
 import gomushin.backend.schedule.dto.request.UpsertScheduleRequest
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class UpsertAndDeleteScheduleFacade(
     private val scheduleService: ScheduleService,
+    private val letterService: LetterService,
+    private val commentService: CommentService,
+    private val pictureService: PictureService,
+    private val s3Service: S3Service,
 ) {
 
     fun upsert(customUserDetails: CustomUserDetails, upsertScheduleRequest: UpsertScheduleRequest) {
@@ -19,7 +28,19 @@ class UpsertAndDeleteScheduleFacade(
         )
     }
 
+    @Transactional
     fun delete(customUserDetails: CustomUserDetails, scheduleId: Long) {
+        val schedule = scheduleService.getById(scheduleId)
+        letterService.findByCoupleAndSchedule(customUserDetails.getCouple(), schedule).forEach { letter ->
+            pictureService.findAllByLetter(letter)
+                .takeIf { it.isNotEmpty() }
+                ?.forEach { picture ->
+                    s3Service.deleteFile(picture.pictureUrl)
+                }
+            pictureService.deleteAllByLetterId(letter.id)
+            commentService.deleteAllByLetterId(letter.id)
+            letterService.delete(letter.id)
+        }
         scheduleService.delete(customUserDetails.getCouple().id, customUserDetails.getId(), scheduleId)
     }
 }

--- a/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteScheduleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/UpsertAndDeleteScheduleFacade.kt
@@ -32,6 +32,7 @@ class UpsertAndDeleteScheduleFacade(
     fun delete(customUserDetails: CustomUserDetails, scheduleId: Long) {
         val schedule = scheduleService.getById(scheduleId)
         letterService.findByCoupleAndSchedule(customUserDetails.getCouple(), schedule).forEach { letter ->
+            // TODO: S3 삭제 로직 트랜잭션 커밋 이후로 분리 + 이벤트 발행으로 처리하기
             pictureService.findAllByLetter(letter)
                 .takeIf { it.isNotEmpty() }
                 ?.forEach { picture ->

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
@@ -49,7 +49,8 @@ class ReadLetterController(
         @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
     ): PageResponse<LetterPreviewResponse> {
-        val letters = readLetterFacade.getLetterListToCouple(customUserDetails, page - 1, size);
+        val safePage = if (page < 1) 0 else page - 1
+        val letters = readLetterFacade.getLetterListToCouple(customUserDetails, safePage, size)
         return letters
     }
 

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/ReadLetterController.kt
@@ -46,10 +46,10 @@ class ReadLetterController(
     @Operation(summary = "커플 전체 편지 리스트 가져오기", description = "getLetterListToMe")
     fun getLetterListToMe(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
-        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
     ): PageResponse<LetterPreviewResponse> {
-        val letters = readLetterFacade.getLetterListToCouple(customUserDetails, page, size);
+        val letters = readLetterFacade.getLetterListToCouple(customUserDetails, page - 1, size);
         return letters
     }
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 월별 스케쥴 반환 시 디데이 추가
- 일정 삭제의 경우, 일정에 관련된 모든 자료 일괄 삭제
- 페이지네이션 1번부터 진행되도록 수정

---

## ✏️ 관련 이슈

- Resolves : #103 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 쪽지와 일정 관련 서비스에 연관된 댓글 및 사진을 일괄 삭제하는 기능이 추가되었습니다.
    - 월별 일정 및 기념일 응답에 기념일 정보가 다시 포함됩니다.
    - 커플과 일정 ID로 쪽지 목록을 조회할 수 있는 기능이 추가되었습니다.

- **버그 수정**
    - 쪽지 목록 조회 및 기념일 목록 조회 시 페이지 번호가 1부터 시작하도록 기본값이 변경되었습니다.

- **개선 사항**
    - 일정 삭제 시 연관된 쪽지, 사진, 댓글, S3 저장소 파일까지 모두 안전하게 삭제됩니다.
    - 접근 거부 시 에러 메시지 로깅이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->