### PR TITLE
Issue: (#108) 알림내역 redis저장 로직 따로 서비스 파서 분리하기

### DIFF
--- a/src/main/kotlin/gomushin/backend/alarm/facade/DdayAlarmFacade.kt
+++ b/src/main/kotlin/gomushin/backend/alarm/facade/DdayAlarmFacade.kt
@@ -1,7 +1,7 @@
 package gomushin.backend.alarm.facade
 
 import gomushin.backend.alarm.service.FCMService
-import gomushin.backend.core.configuration.redis.RedisService
+import gomushin.backend.alarm.service.NotificationRedisService
 import gomushin.backend.couple.domain.service.AnniversaryService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -18,7 +18,7 @@ import java.time.LocalDateTime
 class DdayAlarmFacade(
     private val fcmService: FCMService,
     private val anniversaryService: AnniversaryService,
-    private val redisService: RedisService
+    private val notificationRedisService: NotificationRedisService
 ) {
     private val log: Logger = LoggerFactory.getLogger(QuestionAlarmFacade::class.java)
     private val alarmTitle = "오늘의 디데이가 도착했어요"
@@ -32,7 +32,7 @@ class DdayAlarmFacade(
                 async(Dispatchers.IO) {
                     try {
                         log.info("디데이 메시지 전송 : 수신자 {${content.memberId}}, 제목 {${alarmTitle}}, 내용{${content.title}}, 전송시각{${LocalDateTime.now()}}\n")
-                        redisService.saveAlarm(alarmTitle, content.title, content.memberId)
+                        notificationRedisService.saveAlarm(alarmTitle, content.title, content.memberId)
                         fcmService.sendMessageTo(content.fcmToken, alarmTitle, content.title)
                     } catch (e: Exception) {
                         log.error("디데이 메시지 전송오류 : 수신자 {${content.memberId}}, 전송시각{${LocalDateTime.now()}}\n")

--- a/src/main/kotlin/gomushin/backend/alarm/facade/QuestionAlarmFacade.kt
+++ b/src/main/kotlin/gomushin/backend/alarm/facade/QuestionAlarmFacade.kt
@@ -2,7 +2,7 @@ package gomushin.backend.alarm.facade
 
 import gomushin.backend.alarm.service.FCMService
 import gomushin.backend.alarm.util.MessageParsingUtil
-import gomushin.backend.core.configuration.redis.RedisService
+import gomushin.backend.alarm.service.NotificationRedisService
 import gomushin.backend.member.domain.service.MemberService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -18,7 +18,7 @@ import java.time.LocalDateTime
 class QuestionAlarmFacade (
     private val fcmService: FCMService,
     private val memberService: MemberService,
-    private val redisService: RedisService
+    private val notificationRedisService: NotificationRedisService
 ) {
     private val log: Logger = LoggerFactory.getLogger(QuestionAlarmFacade::class.java)
     private val questionMessages = listOf(
@@ -38,7 +38,7 @@ class QuestionAlarmFacade (
                         val notificationContent = questionMessages.random()
                         val (title, sendContent) = MessageParsingUtil.parse(notificationContent)
                         log.info("질문형 메시지 전송 : 수신자 {${member.id}}, 제목 {${title}}, 내용{${sendContent}}, 전송시각{${LocalDateTime.now()}}\n")
-                        redisService.saveAlarm(title, sendContent, member.id)
+                        notificationRedisService.saveAlarm(title, sendContent, member.id)
                         fcmService.sendMessageTo(member.fcmToken, title, sendContent)
                     } catch (e: Exception) {
                         log.error("질문형 메시지 전송오류 : 수신자 {${member.name}}, 전송시각{${LocalDateTime.now()}}\n")

--- a/src/main/kotlin/gomushin/backend/alarm/service/NotificationRedisService.kt
+++ b/src/main/kotlin/gomushin/backend/alarm/service/NotificationRedisService.kt
@@ -1,14 +1,15 @@
-package gomushin.backend.core.configuration.redis
+package gomushin.backend.alarm.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import gomushin.backend.alarm.dto.SaveAlarmMessage
+import gomushin.backend.core.configuration.redis.RedisKey
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Service
-class RedisService (
+class NotificationRedisService (
     private val redisTemplate: StringRedisTemplate,
     private val objectMapper: ObjectMapper
 ) {

--- a/src/main/kotlin/gomushin/backend/alarm/service/StatusAlarmService.kt
+++ b/src/main/kotlin/gomushin/backend/alarm/service/StatusAlarmService.kt
@@ -1,7 +1,6 @@
 package gomushin.backend.alarm.service
 
 import gomushin.backend.alarm.util.MessageParsingUtil
-import gomushin.backend.core.configuration.redis.RedisService
 import gomushin.backend.core.infrastructure.exception.BadRequestException
 import gomushin.backend.member.domain.entity.Member
 import gomushin.backend.member.domain.value.Emotion
@@ -11,7 +10,7 @@ import org.springframework.stereotype.Service
 @Service
 class StatusAlarmService (
     private val fcmService: FCMService,
-    private val redisService: RedisService
+    private val notificationRedisService: NotificationRedisService
 ) {
     private val statusMessage: Map<Emotion, List<String>> = mapOf(
         Emotion.MISS to listOf(
@@ -56,7 +55,7 @@ class StatusAlarmService (
             content
         }
         val token = receiver.fcmToken
-        redisService.saveAlarm(title, sendContent, receiver.id)
+        notificationRedisService.saveAlarm(title, sendContent, receiver.id)
         fcmService.sendMessageTo(token, title, sendContent)
     }
 }

--- a/src/main/kotlin/gomushin/backend/member/facade/MemberInfoFacade.kt
+++ b/src/main/kotlin/gomushin/backend/member/facade/MemberInfoFacade.kt
@@ -3,7 +3,7 @@ package gomushin.backend.member.facade
 import gomushin.backend.alarm.dto.SaveAlarmMessage
 import gomushin.backend.alarm.service.StatusAlarmService
 import gomushin.backend.core.CustomUserDetails
-import gomushin.backend.core.configuration.redis.RedisService
+import gomushin.backend.alarm.service.NotificationRedisService
 import gomushin.backend.couple.domain.service.CoupleInfoService
 import gomushin.backend.member.domain.service.MemberService
 import gomushin.backend.member.domain.service.NotificationService
@@ -24,7 +24,7 @@ class MemberInfoFacade(
     private val notificationService: NotificationService,
     private val statusAlarmService: StatusAlarmService,
     private val coupleInfoService: CoupleInfoService,
-    private val redisService: RedisService
+    private val notificationRedisService: NotificationRedisService
 ) {
     fun getMemberInfo(customUserDetails: CustomUserDetails): MyInfoResponse {
         val member = memberService.getById(customUserDetails.getId())
@@ -71,6 +71,6 @@ class MemberInfoFacade(
     }
 
     fun getMyReceivedNotification(customUserDetails: CustomUserDetails, recentDays: Long): List<SaveAlarmMessage> {
-        return redisService.getAlarms(customUserDetails.getId(), recentDays)
+        return notificationRedisService.getAlarms(customUserDetails.getId(), recentDays)
     }
 }

--- a/src/test/kotlin/gomushin/backend/member/facade/MemberInfoFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/member/facade/MemberInfoFacadeTest.kt
@@ -2,7 +2,7 @@ package gomushin.backend.member.facade
 
 import gomushin.backend.alarm.service.StatusAlarmService
 import gomushin.backend.core.CustomUserDetails
-import gomushin.backend.core.configuration.redis.RedisService
+import gomushin.backend.alarm.service.NotificationRedisService
 import gomushin.backend.couple.domain.service.CoupleInfoService
 import gomushin.backend.member.domain.entity.Member
 import gomushin.backend.member.domain.entity.Notification
@@ -37,7 +37,7 @@ class MemberInfoFacadeTest {
     @Mock
     private lateinit var coupleInfoService: CoupleInfoService
     @Mock
-    private lateinit var redisService: RedisService
+    private lateinit var notificationRedisService: NotificationRedisService
 
     @InjectMocks
     private lateinit var memberInfoFacade: MemberInfoFacade


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
#108 
- 알림내역 redis저장 로직 따로 서비스 파서 분리하기

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 알림 관련 Redis 서비스가 `RedisService`에서 `NotificationRedisService`로 변경되었습니다.
- **Tests**
  - 테스트 코드에서 Redis 서비스 모킹이 `NotificationRedisService`로 교체되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->