### PR TITLE
Issue: (#111) 기념일 리팩토링 및 테스트코드 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 group = "gomushin"
 version = "0.0.1-SNAPSHOT"
 
+val mockkVersion = "1.13.10"
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
@@ -83,6 +85,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.0.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("io.mockk:mockk:${mockkVersion}")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/kotlin/gomushin/backend/core/oauth/handler/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/gomushin/backend/core/oauth/handler/CustomAccessDeniedHandler.kt
@@ -26,7 +26,6 @@ class CustomAccessDeniedHandler(private val objectMapper: ObjectMapper) : Access
         response.status = HttpServletResponse.SC_FORBIDDEN
         response.characterEncoding = "UTF-8"
 
-        // 정확히 어떤 이유로 발생한 에러인지 보려면 어떻게 해야하나
         logger.error("Access Denied: ${accessDeniedException.message}")
 
         val errorCode = if (request.requestURI.contains("/v1/member/onboarding")) {

--- a/src/main/kotlin/gomushin/backend/couple/domain/service/AnniversaryService.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/service/AnniversaryService.kt
@@ -28,7 +28,7 @@ class AnniversaryService(
     }
 
     @Transactional(readOnly = true)
-    fun findByCoupleIdAndDateBetween(
+    fun findByCoupleAndDateBetween(
         couple: Couple,
         startDate: LocalDate,
         endDate: LocalDate
@@ -37,12 +37,12 @@ class AnniversaryService(
     }
 
     @Transactional(readOnly = true)
-    fun findByCoupleIdAndYearAndMonth(couple: Couple, year: Int, month: Int): List<MonthlyAnniversariesResponse> {
+    fun findByCoupleAndYearAndMonth(couple: Couple, year: Int, month: Int): List<MonthlyAnniversariesResponse> {
         return anniversaryRepository.findByCoupleIdAndYearAndMonth(couple.id, year, month)
     }
 
     @Transactional(readOnly = true)
-    fun findByDate(couple: Couple, date: LocalDate): List<DailyAnniversaryResponse> {
+    fun findByCoupleAndDate(couple: Couple, date: LocalDate): List<DailyAnniversaryResponse> {
         return anniversaryRepository.findByCoupleIdAndDate(couple.id, date)
     }
 

--- a/src/main/kotlin/gomushin/backend/couple/facade/AnniversaryFacade.kt
+++ b/src/main/kotlin/gomushin/backend/couple/facade/AnniversaryFacade.kt
@@ -5,15 +5,12 @@ import gomushin.backend.core.common.web.PageResponse
 import gomushin.backend.couple.domain.service.AnniversaryService
 import gomushin.backend.couple.dto.response.MainAnniversaryResponse
 import gomushin.backend.couple.dto.response.TotalAnniversaryResponse
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
 
 @Component
 class AnniversaryFacade(
     private val anniversaryService: AnniversaryService,
-    @Value("\${server.url}")
-    private val baseUrl: String,
 ) {
     fun getAnniversaryListMain(customUserDetails: CustomUserDetails): List<MainAnniversaryResponse> {
         val anniversaries = anniversaryService.getUpcomingTop3Anniversaries(customUserDetails.getCouple())

--- a/src/main/kotlin/gomushin/backend/schedule/facade/ReadScheduleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/ReadScheduleFacade.kt
@@ -24,13 +24,13 @@ class ReadScheduleFacade(
     ): MonthlySchedulesAndAnniversariesResponse {
         val monthlySchedules = scheduleService.findByCoupleIdAndYearAndMonth(customUserDetails.getCouple(), year, month)
         val monthlyAnniversaries =
-            anniversaryService.findByCoupleIdAndYearAndMonth(customUserDetails.getCouple(), year, month)
+            anniversaryService.findByCoupleAndYearAndMonth(customUserDetails.getCouple(), year, month)
         return MonthlySchedulesAndAnniversariesResponse.of(monthlySchedules, monthlyAnniversaries)
     }
 
     fun get(customUserDetails: CustomUserDetails, date: LocalDate): DailySchedulesAndAnniversariesResponse {
         val dailySchedules = scheduleService.findByDate(customUserDetails.getCouple(), date)
-        val dailyAnniversaries = anniversaryService.findByDate(customUserDetails.getCouple(), date)
+        val dailyAnniversaries = anniversaryService.findByCoupleAndDate(customUserDetails.getCouple(), date)
         return DailySchedulesAndAnniversariesResponse.of(dailySchedules, dailyAnniversaries)
     }
 
@@ -53,7 +53,7 @@ class ReadScheduleFacade(
             today,
             today.plusDays(6)
         )
-        val anniversaries = anniversaryService.findByCoupleIdAndDateBetween(
+        val anniversaries = anniversaryService.findByCoupleAndDateBetween(
             customUserDetails.getCouple(),
             today,
             today.plusDays(6)

--- a/src/test/kotlin/gomushin/backend/couple/domain/service/AnniversaryServiceTest.kt
+++ b/src/test/kotlin/gomushin/backend/couple/domain/service/AnniversaryServiceTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import java.time.LocalDate
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @ExtendWith(MockKExtension::class)
@@ -41,13 +42,12 @@ class AnniversaryServiceTest {
         } returns expectedPage
 
         // when
-        val result = anniversaryService.findAnniversaries(couple, pageRequest)
+        anniversaryService.findAnniversaries(couple, pageRequest)
 
         // then
         verify(exactly = 1) {
             anniversaryRepository.findAnniversaries(couple.id, pageRequest)
         }
-        assert(result == expectedPage)
     }
 
     @DisplayName("findByCoupleAndDateBetween 는 Anniversary 엔티티를 List 형태로 반환한다.")
@@ -64,13 +64,12 @@ class AnniversaryServiceTest {
         } returns expectedList
 
         // when
-        val result = anniversaryService.findByCoupleAndDateBetween(couple, startDate, endDate)
+        anniversaryService.findByCoupleAndDateBetween(couple, startDate, endDate)
 
         // then
         verify(exactly = 1) {
             anniversaryRepository.findByCoupleIdAndDateBetween(couple.id, startDate, endDate)
         }
-        assert(result == expectedList)
     }
 
     @DisplayName("findByCoupleAndYearAndMonth 는 Anniversary 엔티티를 List 형태로 반환한다.")
@@ -87,13 +86,12 @@ class AnniversaryServiceTest {
         } returns expectedList
 
         // when
-        val result = anniversaryService.findByCoupleAndYearAndMonth(couple, year, month)
+        anniversaryService.findByCoupleAndYearAndMonth(couple, year, month)
 
         // then
         verify(exactly = 1) {
             anniversaryRepository.findByCoupleIdAndYearAndMonth(couple.id, year, month)
         }
-        assert(result == expectedList)
     }
 
     @DisplayName("findByCoupleAndDate 는 Anniversary 엔티티를 List 형태로 반환한다.")
@@ -109,13 +107,12 @@ class AnniversaryServiceTest {
         } returns expectedList
 
         // when
-        val result = anniversaryService.findByCoupleAndDate(couple, date)
+        anniversaryService.findByCoupleAndDate(couple, date)
 
         // then
         verify(exactly = 1) {
             anniversaryRepository.findByCoupleIdAndDate(couple.id, date)
         }
-        assert(result == expectedList)
     }
 
     @DisplayName("saveAll 은 Anniversary 엔티티를 List 형태로 저장한다.")
@@ -129,13 +126,12 @@ class AnniversaryServiceTest {
         } returns expectedList
 
         // when
-        val result = anniversaryService.saveAll(anniversaries)
+        anniversaryService.saveAll(anniversaries)
 
         // then
         verify(exactly = 1) {
             anniversaryRepository.saveAll(anniversaries)
         }
-        assert(result == expectedList)
     }
 
     @DisplayName("getUpcomingTop3Anniversaries 는 Anniversary 엔티티를 List 형태로 반환하고, 최대 3개를 반환한다.")
@@ -159,6 +155,34 @@ class AnniversaryServiceTest {
 
         // then
         assertTrue(result.size <= 3, "반환된 기념일의 개수는 최대 3개여야 합니다.")
+    }
+
+    @DisplayName("getUpcomingTop3Anniversaries 는 Anniversary 엔티티를 List 형태로 반환하고, 시간 순으로 정렬한다.")
+    @Test
+    fun getUpcomingTop3Anniversaries_sortedByDate() {
+        // given
+        val couple = Couple(1L, 1L, 2L)
+        val expectedList = listOf<Anniversary>(
+            Anniversary(1L, couple.id, "Anniversary 1", LocalDate.of(2025, 1, 1), 1),
+            Anniversary(2L, couple.id, "Anniversary 2", LocalDate.of(2025, 2, 1), 1),
+            Anniversary(3L, couple.id, "Anniversary 3", LocalDate.of(2025, 3, 1), 1),
+            Anniversary(4L, couple.id, "Anniversary 4", LocalDate.of(2025, 4, 1), 1),
+        )
+
+        every {
+            anniversaryRepository.findTop3UpcomingAnniversaries(couple.id)
+        } returns expectedList.take(3)
+
+        // when
+        val result = anniversaryService.getUpcomingTop3Anniversaries(couple)
+
+        // then
+        assertEquals(result, expectedList.take(3))
+        assertEquals(
+            result.map { it.anniversaryDate }.sorted(),
+            result.map { it.anniversaryDate },
+            "반환된 기념일은 시간 순으로 정렬되어야 합니다."
+        )
     }
 }
 

--- a/src/test/kotlin/gomushin/backend/couple/domain/service/AnniversaryServiceTest.kt
+++ b/src/test/kotlin/gomushin/backend/couple/domain/service/AnniversaryServiceTest.kt
@@ -1,0 +1,164 @@
+package gomushin.backend.couple.domain.service
+
+import gomushin.backend.couple.domain.entity.Anniversary
+import gomushin.backend.couple.domain.entity.Couple
+import gomushin.backend.couple.domain.repository.AnniversaryRepository
+import gomushin.backend.couple.dto.response.MonthlyAnniversariesResponse
+import gomushin.backend.schedule.dto.response.DailyAnniversaryResponse
+import gomushin.backend.schedule.dto.response.MainAnniversariesResponse
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDate
+import kotlin.test.assertTrue
+
+@ExtendWith(MockKExtension::class)
+class AnniversaryServiceTest {
+    @MockK
+    lateinit var anniversaryRepository: AnniversaryRepository
+
+    @InjectMockKs
+    lateinit var anniversaryService: AnniversaryService
+
+    @DisplayName("findAnniversaries 는 Anniversary 엔티티를 Page 형태로 반환한다.")
+    @Test
+    fun findAnniversaries_success() {
+        // given
+        val couple = Couple(1L, 1L, 2L)
+        val pageRequest = PageRequest.of(0, 10)
+        val expectedPage = mockk<Page<Anniversary>>()
+
+        every {
+            anniversaryRepository.findAnniversaries(couple.id, pageRequest)
+        } returns expectedPage
+
+        // when
+        val result = anniversaryService.findAnniversaries(couple, pageRequest)
+
+        // then
+        verify(exactly = 1) {
+            anniversaryRepository.findAnniversaries(couple.id, pageRequest)
+        }
+        assert(result == expectedPage)
+    }
+
+    @DisplayName("findByCoupleAndDateBetween 는 Anniversary 엔티티를 List 형태로 반환한다.")
+    @Test
+    fun findByCoupleAndDateBetween_success() {
+        // given
+        val couple = Couple(1L, 1L, 2L)
+        val startDate = LocalDate.of(2025, 1, 1)
+        val endDate = LocalDate.of(2025, 12, 31)
+        val expectedList = listOf<MainAnniversariesResponse>()
+
+        every {
+            anniversaryRepository.findByCoupleIdAndDateBetween(couple.id, startDate, endDate)
+        } returns expectedList
+
+        // when
+        val result = anniversaryService.findByCoupleAndDateBetween(couple, startDate, endDate)
+
+        // then
+        verify(exactly = 1) {
+            anniversaryRepository.findByCoupleIdAndDateBetween(couple.id, startDate, endDate)
+        }
+        assert(result == expectedList)
+    }
+
+    @DisplayName("findByCoupleAndYearAndMonth 는 Anniversary 엔티티를 List 형태로 반환한다.")
+    @Test
+    fun findByCoupleAndYearAndMonth_success() {
+        // given
+        val couple = Couple(1L, 1L, 2L)
+        val year = 2025
+        val month = 1
+        val expectedList = listOf<MonthlyAnniversariesResponse>()
+
+        every {
+            anniversaryRepository.findByCoupleIdAndYearAndMonth(couple.id, year, month)
+        } returns expectedList
+
+        // when
+        val result = anniversaryService.findByCoupleAndYearAndMonth(couple, year, month)
+
+        // then
+        verify(exactly = 1) {
+            anniversaryRepository.findByCoupleIdAndYearAndMonth(couple.id, year, month)
+        }
+        assert(result == expectedList)
+    }
+
+    @DisplayName("findByCoupleAndDate 는 Anniversary 엔티티를 List 형태로 반환한다.")
+    @Test
+    fun findByCoupleAndDate_success() {
+        // given
+        val couple = Couple(1L, 1L, 2L)
+        val date = LocalDate.of(2025, 1, 1)
+        val expectedList = listOf<DailyAnniversaryResponse>()
+
+        every {
+            anniversaryRepository.findByCoupleIdAndDate(couple.id, date)
+        } returns expectedList
+
+        // when
+        val result = anniversaryService.findByCoupleAndDate(couple, date)
+
+        // then
+        verify(exactly = 1) {
+            anniversaryRepository.findByCoupleIdAndDate(couple.id, date)
+        }
+        assert(result == expectedList)
+    }
+
+    @DisplayName("saveAll 은 Anniversary 엔티티를 List 형태로 저장한다.")
+    @Test
+    fun saveAll_success() {
+        // given
+        val anniversaries = listOf<Anniversary>()
+        val expectedList = listOf<Anniversary>()
+        every {
+            anniversaryRepository.saveAll(anniversaries)
+        } returns expectedList
+
+        // when
+        val result = anniversaryService.saveAll(anniversaries)
+
+        // then
+        verify(exactly = 1) {
+            anniversaryRepository.saveAll(anniversaries)
+        }
+        assert(result == expectedList)
+    }
+
+    @DisplayName("getUpcomingTop3Anniversaries 는 Anniversary 엔티티를 List 형태로 반환하고, 최대 3개를 반환한다.")
+    @Test
+    fun getUpcomingTop3Anniversaries_success() {
+        // given
+        val couple = Couple(1L, 1L, 2L)
+        val expectedList = listOf<Anniversary>(
+            Anniversary(1L, couple.id, "Anniversary 1", LocalDate.of(2025, 1, 1), 1),
+            Anniversary(2L, couple.id, "Anniversary 2", LocalDate.of(2025, 2, 1), 1),
+            Anniversary(3L, couple.id, "Anniversary 3", LocalDate.of(2025, 3, 1), 1),
+            Anniversary(4L, couple.id, "Anniversary 4", LocalDate.of(2025, 3, 1), 1)
+        )
+
+        every {
+            anniversaryRepository.findTop3UpcomingAnniversaries(couple.id)
+        } returns expectedList.take(3)
+
+        // when
+        val result = anniversaryService.getUpcomingTop3Anniversaries(couple)
+
+        // then
+        assertTrue(result.size <= 3, "반환된 기념일의 개수는 최대 3개여야 합니다.")
+    }
+}
+

--- a/src/test/kotlin/gomushin/backend/couple/facade/AnniversaryFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/couple/facade/AnniversaryFacadeTest.kt
@@ -51,7 +51,6 @@ class AnniversaryFacadeTest {
         verify(exactly = 1) {
             anniversaryService.getUpcomingTop3Anniversaries(couple)
         }
-        assert(result == anniversaryResponseList)
     }
 
     @DisplayName("getAnniversaryList 은 AnniversaryService 의 findAnniversaries 를 호출한다.")

--- a/src/test/kotlin/gomushin/backend/couple/facade/AnniversaryFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/couple/facade/AnniversaryFacadeTest.kt
@@ -1,0 +1,88 @@
+package gomushin.backend.couple.facade
+
+import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.couple.domain.entity.Anniversary
+import gomushin.backend.couple.domain.entity.Couple
+import gomushin.backend.couple.domain.service.AnniversaryService
+import gomushin.backend.schedule.dto.response.MainAnniversariesResponse
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDate
+
+@ExtendWith(MockKExtension::class)
+class AnniversaryFacadeTest {
+    @MockK
+    lateinit var anniversaryService: AnniversaryService
+
+    @InjectMockKs
+    lateinit var anniversaryFacade: AnniversaryFacade
+
+    @DisplayName("getAnniversaryListMain 은 AnniversaryService 의 getUpcomingTop3Anniversaries 를 호출한다.")
+    @Test
+    fun getAnniversaryListMain_success() {
+        // given
+        val customUserDetails = mockk<CustomUserDetails>()
+        val couple = mockk<Couple>()
+        val anniversaryList = listOf<Anniversary>()
+        val anniversaryResponseList = listOf<MainAnniversariesResponse>()
+
+        every {
+            customUserDetails.getCouple()
+        } returns couple
+
+        every {
+            anniversaryService.getUpcomingTop3Anniversaries(couple)
+        } returns anniversaryList
+
+        // when
+        val result = anniversaryFacade.getAnniversaryListMain(customUserDetails)
+
+        // then
+        verify(exactly = 1) {
+            anniversaryService.getUpcomingTop3Anniversaries(couple)
+        }
+        assert(result == anniversaryResponseList)
+    }
+
+    @DisplayName("getAnniversaryList 은 AnniversaryService 의 findAnniversaries 를 호출한다.")
+    @Test
+    fun getAnniversaryList_success() {
+        // given
+        val customUserDetails = mockk<CustomUserDetails>()
+        val couple = mockk<Couple>()
+        val page = 0
+        val size = 10
+        val pageRequest = PageRequest.of(page, size)
+
+        val content = listOf(
+            Anniversary(1L, 1L, "Anniversary 1", LocalDate.of(2023, 10, 1), 1),
+            Anniversary(2L, 2L, "Anniversary 2", LocalDate.of(2023, 10, 2), 1)
+        )
+        val anniversaries = PageImpl(content)
+
+        every { customUserDetails.getCouple() } returns couple
+        every {
+            anniversaryService.findAnniversaries(couple, pageRequest)
+        } returns anniversaries
+
+        // when
+        val result = anniversaryFacade.getAnniversaryList(customUserDetails, page, size)
+
+        // then
+        verify(exactly = 1) {
+            anniversaryService.findAnniversaries(couple, pageRequest)
+        }
+        assertThat(result.data).hasSize(2)
+        assertThat(result.totalPages).isEqualTo(1)
+    }
+}

--- a/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadScheduleFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadScheduleFacadeTest.kt
@@ -61,13 +61,13 @@ class ReadScheduleFacadeTest {
         // when
         `when`(scheduleService.findByCoupleIdAndYearAndMonth(customUserDetails.getCouple(), year, month))
             .thenReturn(listOf(monthlySchedulesResponse))
-        `when`(anniversaryService.findByCoupleIdAndYearAndMonth(customUserDetails.getCouple(), year, month))
+        `when`(anniversaryService.findByCoupleAndYearAndMonth(customUserDetails.getCouple(), year, month))
             .thenReturn(listOf(monthlyAnniversariesResponse))
         readScheduleFacade.getList(customUserDetails, year, month)
 
         // then
         verify(scheduleService, times(1)).findByCoupleIdAndYearAndMonth(customUserDetails.getCouple(), year, month)
-        verify(anniversaryService, times(1)).findByCoupleIdAndYearAndMonth(customUserDetails.getCouple(), year, month)
+        verify(anniversaryService, times(1)).findByCoupleAndYearAndMonth(customUserDetails.getCouple(), year, month)
     }
 
     @DisplayName("get - 성공")


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- AnniversaryService 내 파라미터로 Couple을 사용하는 경우, 메서드 명을 수정함
- 테스트 코드 작성

---

## ✏️ 관련 이슈
- Resolves : #111 
---

## 🎸 기타 사항 or 추가 코멘트

AnniversaryService에서 내가 짠 메서드만 테스트코드 작성했어

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩터링**
    - AnniversaryService의 메서드 명칭을 일관성 있게 변경하여 가독성을 향상시켰습니다.
    - AnniversaryFacade 생성자에서 불필요한 외부 설정 의존성을 제거했습니다.
    - 관련된 서비스 및 테스트 코드에서 변경된 메서드명을 반영했습니다.

- **테스트**
    - AnniversaryService와 AnniversaryFacade에 대한 단위 테스트를 추가하여 안정성을 강화했습니다.
    - ReadScheduleFacade 테스트에서 AnniversaryService 메서드명 변경을 반영했습니다.

- **기타**
    - 테스트를 위한 MockK 라이브러리 의존성을 추가했습니다.
    - 불필요한 주석을 제거했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->