### PR TITLE
Issue: (#123) 온보딩 여부에 따른 리다이렉트 주소 변경

### DIFF
--- a/src/main/kotlin/gomushin/backend/core/configuration/security/CustomCorsConfiguration.kt
+++ b/src/main/kotlin/gomushin/backend/core/configuration/security/CustomCorsConfiguration.kt
@@ -20,7 +20,8 @@ class CustomCorsConfiguration {
                 "https://frontend-sarang.vercel.app",
                 "https://vite.sarang-backend.o-r.kr:5173",
                 "https://sarang-backend.o-r.kr",
-                "https://www.sarangkkun.site"
+                "https://www.sarangkkun.site",
+                "https://sarangkkun.site",
             )
         configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
         configuration.allowedHeaders = listOf("*")

--- a/src/main/kotlin/gomushin/backend/core/configuration/security/SecurityConfiguration.kt
+++ b/src/main/kotlin/gomushin/backend/core/configuration/security/SecurityConfiguration.kt
@@ -26,7 +26,8 @@ class SecurityConfiguration(
     private val tokenService: TokenService,
     private val memberRepository: MemberRepository,
     private val cookieService: CookieService,
-    @Value("\${redirect-url}") private val redirectUrl: String
+    @Value("\${member-redirect-url}") private val memberRedirectUrl: String,
+    @Value("\${guest-redirect-url}") private val guestRedirectUrl: String,
 ) {
 
     @Bean
@@ -65,7 +66,8 @@ class SecurityConfiguration(
                             tokenService,
                             memberRepository,
                             cookieService,
-                            redirectUrl,
+                            memberRedirectUrl,
+                            guestRedirectUrl,
                         )
                     )
             }

--- a/src/main/kotlin/gomushin/backend/member/domain/value/Role.kt
+++ b/src/main/kotlin/gomushin/backend/member/domain/value/Role.kt
@@ -1,6 +1,15 @@
 package gomushin.backend.member.domain.value
 
+import gomushin.backend.core.infrastructure.exception.BadRequestException
+
 enum class Role {
     GUEST,
-    MEMBER,
+    MEMBER;
+
+    companion object {
+        fun getByName(name: String): Role {
+            return entries.firstOrNull { it.name == name }
+                ?: throw BadRequestException("sarangggun.member.not-exist-role")
+        }
+    }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 멤버 온보딩 여부에 따른 리다이렉트 주소 변경

---

## ✏️ 관련 이슈

- Resolves : #123

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - OAuth2 인증 성공 시, 사용자의 역할(멤버/게스트)에 따라 서로 다른 URL로 리다이렉트됩니다.
  - 역할 이름으로 Role을 조회할 수 있는 기능이 추가되었습니다. 존재하지 않는 역할명 입력 시 오류가 발생합니다.

- **기타**
  - 배포 워크플로우가 main 브랜치로의 풀리퀘스트에도 동작하도록 개선되었습니다.
  - CORS 설정에 새로운 허용 출처(https://www.sarangkkun.site)가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->