### PR TITLE
Issue : (#132) Schedule관련 api 보강

### DIFF
--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterDetailResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterDetailResponse.kt
@@ -3,7 +3,7 @@ package gomushin.backend.schedule.dto.response
 data class LetterDetailResponse(
     val letter: LetterResponse,
     val pictures: List<PictureResponse>,
-    val comments: List<CommentResponse>,
+    val comments: List<CommentResponse>
 ) {
     companion object {
         fun of(
@@ -14,7 +14,7 @@ data class LetterDetailResponse(
             return LetterDetailResponse(
                 letter = letter,
                 pictures = pictures,
-                comments = comments,
+                comments = comments
             )
         }
     }

--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterDetailResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterDetailResponse.kt
@@ -3,7 +3,7 @@ package gomushin.backend.schedule.dto.response
 data class LetterDetailResponse(
     val letter: LetterResponse,
     val pictures: List<PictureResponse>,
-    val comments: List<CommentResponse>
+    val comments: List<CommentResponse>,
 ) {
     companion object {
         fun of(
@@ -14,7 +14,7 @@ data class LetterDetailResponse(
             return LetterDetailResponse(
                 letter = letter,
                 pictures = pictures,
-                comments = comments
+                comments = comments,
             )
         }
     }

--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterPreviewResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterPreviewResponse.kt
@@ -1,5 +1,6 @@
 package gomushin.backend.schedule.dto.response
 
+import gomushin.backend.member.domain.entity.Member
 import gomushin.backend.schedule.domain.entity.Letter
 import gomushin.backend.schedule.domain.entity.Picture
 import gomushin.backend.schedule.domain.entity.Schedule
@@ -23,7 +24,7 @@ data class LetterPreviewResponse(
             letter: Letter?,
             schedule: Schedule?,
             picture: Picture?,
-            memberId : Long?
+            member : Member?,
         ): LetterPreviewResponse {
             val previewContent = if (letter?.content != null && letter.content.length > MAX_CONTENT_LENGTH) {
                 letter.content.take(PREVIEW_CONTENT_LENGTH) + "..."
@@ -37,7 +38,7 @@ data class LetterPreviewResponse(
                 title = letter?.title,
                 content = previewContent,
                 pictureUrl = picture?.pictureUrl,
-                isWrittenByMe = memberId == letter?.authorId,
+                isWrittenByMe = member?.id == letter?.authorId,
                 createdAt = letter?.createdAt
             )
         }

--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterPreviewResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterPreviewResponse.kt
@@ -12,6 +12,7 @@ data class LetterPreviewResponse(
     val title: String?,
     val content: String?,
     val pictureUrl: String?,
+    val isWrittenByMe : Boolean?,
     val createdAt: LocalDateTime?,
 ) {
     companion object {
@@ -21,7 +22,8 @@ data class LetterPreviewResponse(
         fun of(
             letter: Letter?,
             schedule: Schedule?,
-            picture: Picture?
+            picture: Picture?,
+            memberId : Long?
         ): LetterPreviewResponse {
             val previewContent = if (letter?.content != null && letter.content.length > MAX_CONTENT_LENGTH) {
                 letter.content.take(PREVIEW_CONTENT_LENGTH) + "..."
@@ -35,6 +37,7 @@ data class LetterPreviewResponse(
                 title = letter?.title,
                 content = previewContent,
                 pictureUrl = picture?.pictureUrl,
+                isWrittenByMe = memberId == letter?.authorId,
                 createdAt = letter?.createdAt
             )
         }

--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/LetterResponse.kt
@@ -8,15 +8,17 @@ data class LetterResponse(
     val title: String,
     val content: String,
     val author: String,
+    val isWrittenByMe : Boolean,
     val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun of(letter: Letter): LetterResponse {
+        fun of(letter: Letter, memberId : Long): LetterResponse {
             return LetterResponse(
                 id = letter.id,
                 title = letter.title,
                 content = letter.content,
                 author = letter.author,
+                isWrittenByMe = letter.authorId == memberId,
                 createdAt = letter.createdAt,
             )
         }

--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/MainLetterPreviewResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/MainLetterPreviewResponse.kt
@@ -12,6 +12,7 @@ data class MainLetterPreviewResponse(
     val pictureUrl: String?,
     val schedule: String?,
     val scheduleId : Long?,
+    val isWrittenByMe : Boolean?,
     val createdAt: LocalDateTime?,
 ) {
     companion object {
@@ -22,6 +23,7 @@ data class MainLetterPreviewResponse(
             letter: Letter?,
             picture: Picture?,
             schedule: Schedule?,
+            memberId : Long?
         ): MainLetterPreviewResponse {
             val previewContent = if (letter?.content != null && letter.content.length > MAX_CONTENT_LENGTH) {
                 letter.content.take(PREVIEW_CONTENT_LENGTH) + "..."
@@ -35,6 +37,7 @@ data class MainLetterPreviewResponse(
                 pictureUrl = picture?.pictureUrl,
                 schedule = schedule?.title,
                 scheduleId = schedule?.id,
+                isWrittenByMe = memberId == letter?.authorId,
                 createdAt = letter?.createdAt
             )
         }

--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/MainLetterPreviewResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/MainLetterPreviewResponse.kt
@@ -11,6 +11,7 @@ data class MainLetterPreviewResponse(
     val content: String?,
     val pictureUrl: String?,
     val schedule: String?,
+    val scheduleId : Long?,
     val createdAt: LocalDateTime?,
 ) {
     companion object {
@@ -33,6 +34,7 @@ data class MainLetterPreviewResponse(
                 content = previewContent,
                 pictureUrl = picture?.pictureUrl,
                 schedule = schedule?.title,
+                scheduleId = schedule?.id,
                 createdAt = letter?.createdAt
             )
         }

--- a/src/main/kotlin/gomushin/backend/schedule/dto/response/MainLetterPreviewResponse.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/dto/response/MainLetterPreviewResponse.kt
@@ -1,5 +1,6 @@
 package gomushin.backend.schedule.dto.response
 
+import gomushin.backend.member.domain.entity.Member
 import gomushin.backend.schedule.domain.entity.Letter
 import gomushin.backend.schedule.domain.entity.Picture
 import gomushin.backend.schedule.domain.entity.Schedule
@@ -23,7 +24,7 @@ data class MainLetterPreviewResponse(
             letter: Letter?,
             picture: Picture?,
             schedule: Schedule?,
-            memberId : Long?
+            member : Member?,
         ): MainLetterPreviewResponse {
             val previewContent = if (letter?.content != null && letter.content.length > MAX_CONTENT_LENGTH) {
                 letter.content.take(PREVIEW_CONTENT_LENGTH) + "..."
@@ -37,7 +38,7 @@ data class MainLetterPreviewResponse(
                 pictureUrl = picture?.pictureUrl,
                 schedule = schedule?.title,
                 scheduleId = schedule?.id,
-                isWrittenByMe = memberId == letter?.authorId,
+                isWrittenByMe = member?.id == letter?.authorId,
                 createdAt = letter?.createdAt
             )
         }

--- a/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/ReadLetterFacade.kt
@@ -26,6 +26,7 @@ class ReadLetterFacade(
         customUserDetails: CustomUserDetails,
         scheduleId: Long,
     ): List<LetterPreviewResponse> {
+        val memberId = customUserDetails.getId()
         val schedule = scheduleService.getById(scheduleId)
         val letters = letterService.findByCoupleAndSchedule(
             customUserDetails.getCouple(),
@@ -33,7 +34,7 @@ class ReadLetterFacade(
         )
         return letters.map { letter ->
             val picture = pictureService.findFirstByLetterId(letter.id)
-            LetterPreviewResponse.of(letter, schedule, picture)
+            LetterPreviewResponse.of(letter, schedule, picture, memberId)
         }
     }
 
@@ -42,6 +43,7 @@ class ReadLetterFacade(
         scheduleId: Long,
         letterId: Long,
     ): LetterDetailResponse {
+        val memberId = customUserDetails.getId()
         val schedule = scheduleService.getById(scheduleId)
         val letter = letterService.getByCoupleAndScheduleAndId(
             customUserDetails.getCouple(),
@@ -49,7 +51,7 @@ class ReadLetterFacade(
             letterId,
         )
 
-        val letterResponse = LetterResponse.of(letter)
+        val letterResponse = LetterResponse.of(letter, memberId)
 
         val pictures = pictureService.findAllByLetter(letter)
         val pictureResponses = pictures.map { picture ->
@@ -74,12 +76,13 @@ class ReadLetterFacade(
         size: Int,
     ): PageResponse<LetterPreviewResponse> {
         val pageRequest = PageRequest.of(page, size)
+        val memberId = customUserDetails.getId()
         val letters = letterService.findAllToCouple(customUserDetails.getCouple(), pageRequest)
 
         val letterPreviewResponses = letters.map { letter ->
             val picture = letter.let { pictureService.findFirstByLetterId(it.id) }
             val schedule = letter.let { scheduleService.getById(it.scheduleId) }
-            LetterPreviewResponse.of(letter, schedule, picture)
+            LetterPreviewResponse.of(letter, schedule, picture, memberId)
         }
 
         return PageResponse.from(letterPreviewResponses)
@@ -89,10 +92,11 @@ class ReadLetterFacade(
         customUserDetails: CustomUserDetails,
     ): List<MainLetterPreviewResponse> {
         val letters = letterService.findTop5ByCreatedDateDesc(customUserDetails.getCouple())
+        val memberId = customUserDetails.getId()
         return letters.map { letter ->
             val picture = pictureService.findFirstByLetterId(letter.id)
             val schedule = scheduleService.findById(letter.scheduleId)
-            MainLetterPreviewResponse.of(letter, picture, schedule)
+            MainLetterPreviewResponse.of(letter, picture, schedule, memberId)
         }
     }
 }

--- a/src/main/kotlin/gomushin/backend/schedule/facade/ReadScheduleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/ReadScheduleFacade.kt
@@ -2,10 +2,12 @@ package gomushin.backend.schedule.facade
 
 import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.couple.domain.service.AnniversaryService
+import gomushin.backend.member.domain.service.MemberService
 import gomushin.backend.schedule.domain.service.LetterService
 import gomushin.backend.schedule.domain.service.PictureService
 import gomushin.backend.schedule.domain.service.ScheduleService
 import gomushin.backend.schedule.dto.response.*
+import kotlinx.coroutines.flow.merge
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 
@@ -14,7 +16,8 @@ class ReadScheduleFacade(
     private val scheduleService: ScheduleService,
     private val anniversaryService: AnniversaryService,
     private val letterService: LetterService,
-    private val pictureService: PictureService
+    private val pictureService: PictureService,
+    private val memberService: MemberService,
 ) {
 
     companion object {
@@ -44,9 +47,9 @@ class ReadScheduleFacade(
         val letterIds = letters.map { it.id }
         val picturesByLetterId = pictureService.findAllByLetterIds(letterIds)
             .associateBy { it.letterId }
-        val memberId = customUserDetails.getId()
+        val member = memberService.getById(customUserDetails.getId())
         val letterPreviews = letters.map { letter ->
-            LetterPreviewResponse.of(letter, schedule, picturesByLetterId[letter.id], memberId)
+            LetterPreviewResponse.of(letter, schedule, picturesByLetterId[letter.id], member)
         }
         return ScheduleDetailResponse.of(schedule, letterPreviews)
     }

--- a/src/main/kotlin/gomushin/backend/schedule/facade/ReadScheduleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/facade/ReadScheduleFacade.kt
@@ -44,8 +44,9 @@ class ReadScheduleFacade(
         val letterIds = letters.map { it.id }
         val picturesByLetterId = pictureService.findAllByLetterIds(letterIds)
             .associateBy { it.letterId }
+        val memberId = customUserDetails.getId()
         val letterPreviews = letters.map { letter ->
-            LetterPreviewResponse.of(letter, schedule, picturesByLetterId[letter.id])
+            LetterPreviewResponse.of(letter, schedule, picturesByLetterId[letter.id], memberId)
         }
         return ScheduleDetailResponse.of(schedule, letterPreviews)
     }

--- a/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadLetterFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadLetterFacadeTest.kt
@@ -2,6 +2,7 @@ package gomushin.backend.schedule.domain.facade
 
 import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.couple.domain.entity.Couple
+import gomushin.backend.member.domain.service.MemberService
 import gomushin.backend.schedule.domain.entity.Letter
 import gomushin.backend.schedule.domain.entity.Picture
 import gomushin.backend.schedule.domain.entity.Schedule
@@ -33,6 +34,9 @@ class ReadLetterFacadeTest {
     @Mock
     lateinit var pictureService: PictureService
 
+    @Mock
+    lateinit var memberService: MemberService
+
     private lateinit var readLetterFacade: ReadLetterFacade
 
 
@@ -44,6 +48,7 @@ class ReadLetterFacadeTest {
             scheduleService,
             pictureService,
             commentService,
+            memberService,
             baseUrl
         )
     }

--- a/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadScheduleFacadeMockkTest.kt
+++ b/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadScheduleFacadeMockkTest.kt
@@ -4,6 +4,7 @@ import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.couple.domain.entity.Couple
 import gomushin.backend.couple.domain.service.AnniversaryService
 import gomushin.backend.couple.dto.response.MonthlyAnniversariesResponse
+import gomushin.backend.member.domain.service.MemberService
 import gomushin.backend.schedule.domain.service.LetterService
 import gomushin.backend.schedule.domain.service.PictureService
 import gomushin.backend.schedule.domain.service.ScheduleService
@@ -18,6 +19,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
 import java.time.LocalDate
 
 @ExtendWith(MockKExtension::class)
@@ -34,6 +36,9 @@ class ReadScheduleFacadeMockkTest {
 
     @MockK
     lateinit var pictureService: PictureService
+
+    @MockK
+    lateinit var memberService: MemberService
 
     @InjectMockKs
     lateinit var readScheduleFacade: ReadScheduleFacade

--- a/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadScheduleFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/schedule/domain/facade/ReadScheduleFacadeTest.kt
@@ -4,6 +4,7 @@ import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.couple.domain.entity.Couple
 import gomushin.backend.couple.domain.service.AnniversaryService
 import gomushin.backend.couple.dto.response.MonthlyAnniversariesResponse
+import gomushin.backend.member.domain.service.MemberService
 import gomushin.backend.schedule.domain.entity.Letter
 import gomushin.backend.schedule.domain.entity.Picture
 import gomushin.backend.schedule.domain.entity.Schedule
@@ -38,6 +39,9 @@ class ReadScheduleFacadeTest {
 
     @Mock
     private lateinit var pictureService: PictureService
+
+    @Mock
+    private lateinit var memberService: MemberService
 
     @InjectMocks
     private lateinit var readScheduleFacade: ReadScheduleFacade


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
#132 
- 메인 화면 편지 리스트 가져오는거에서 스케줄 아이디 같이 보내주기
- 편지 조회 api에서 내가 쓴건지, 상대가 쓴건지 확인할 수 있게 구현

---


## 🎸 기타 사항 or 추가 코멘트

![image](https://github.com/user-attachments/assets/14952e13-077a-4fa3-b9dd-8c1fffe929fe)
![image](https://github.com/user-attachments/assets/0f13341b-7624-424a-94d6-37e0510ad1eb)
![image](https://github.com/user-attachments/assets/eeea9bd1-aeed-4547-a507-e39ed160098f)
![image](https://github.com/user-attachments/assets/7e08d445-39ea-46df-9fd8-2385e2abaaee)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 각 편지 응답에 '내가 작성한 편지인지' 여부를 확인할 수 있는 isWrittenByMe 속성이 추가되었습니다.
    - 메인 편지 미리보기 응답에 scheduleId가 추가되었습니다.

- **버그 수정**
    - 없음

- **테스트**
    - MemberService에 대한 모킹(mocking)이 테스트 코드에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->