### PR TITLE
Issue: (#134) 입대일, 전역일 수정 시 Dday초기설정한거 다시 재업데이트

### DIFF
--- a/src/main/kotlin/gomushin/backend/couple/domain/entity/Anniversary.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/entity/Anniversary.kt
@@ -27,6 +27,9 @@ class Anniversary(
     @Enumerated(EnumType.STRING)
     @Column(name = "anniversary_emoji")
     var emoji: AnniversaryEmoji? = null,
+
+    @Column(name = "is_auto_insert")
+    var isAutoInsert: Boolean = false
 ) : BaseEntity() {
     companion object {
         fun autoCreate(coupleId: Long, title: String, anniversaryDate: LocalDate): Anniversary {
@@ -35,7 +38,8 @@ class Anniversary(
                 title = title,
                 anniversaryDate = anniversaryDate,
                 anniversaryProperty = 0,
-                emoji = AnniversaryEmoji.HEART
+                emoji = AnniversaryEmoji.HEART,
+                isAutoInsert = true
             )
         }
 

--- a/src/main/kotlin/gomushin/backend/couple/domain/entity/Anniversary.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/entity/Anniversary.kt
@@ -29,7 +29,7 @@ class Anniversary(
     var emoji: AnniversaryEmoji? = null,
 
     @Column(name = "is_auto_insert")
-    var isAutoInsert: Boolean = false
+    var isAutoInsert: Boolean = false,
 ) : BaseEntity() {
     companion object {
         fun autoCreate(coupleId: Long, title: String, anniversaryDate: LocalDate): Anniversary {
@@ -39,7 +39,7 @@ class Anniversary(
                 anniversaryDate = anniversaryDate,
                 anniversaryProperty = 0,
                 emoji = AnniversaryEmoji.HEART,
-                isAutoInsert = true
+                isAutoInsert = true,
             )
         }
 

--- a/src/main/kotlin/gomushin/backend/couple/domain/repository/AnniversaryRepository.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/repository/AnniversaryRepository.kt
@@ -119,4 +119,8 @@ interface AnniversaryRepository : JpaRepository<Anniversary, Long> {
         nativeQuery = true
     )
     fun findTodayAnniversaryMemberFcmTokens(@Param("nowDate") date: LocalDate): List<AnniversaryNotificationInfo>
+
+    @Modifying
+    @Query("DELETE FROM Anniversary a WHERE a.coupleId = :coupleId AND a.isAutoInsert = true")
+    fun deleteAllByCoupleIdAndAutoInsertTrue(@Param("coupleId") coupleId: Long)
 }

--- a/src/main/kotlin/gomushin/backend/couple/domain/service/AnniversaryService.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/service/AnniversaryService.kt
@@ -98,7 +98,7 @@ class AnniversaryService(
     }
 
     @Transactional
-    fun deleteAllByCoupleIdAndAutoInsert(couple: Couple) {
+    fun deleteAllByCoupleAndAutoInsert(couple: Couple) {
         return anniversaryRepository.deleteAllByCoupleIdAndAutoInsertTrue(couple.id)
     }
 }

--- a/src/main/kotlin/gomushin/backend/couple/domain/service/AnniversaryService.kt
+++ b/src/main/kotlin/gomushin/backend/couple/domain/service/AnniversaryService.kt
@@ -96,4 +96,9 @@ class AnniversaryService(
         }
         anniversaryRepository.deleteById(anniversaryId)
     }
+
+    @Transactional
+    fun deleteAllByCoupleIdAndAutoInsert(couple: Couple) {
+        return anniversaryRepository.deleteAllByCoupleIdAndAutoInsertTrue(couple.id)
+    }
 }

--- a/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
@@ -94,6 +94,7 @@ class CoupleFacade(
         return StatusMessageResponse.of(statusMessage)
     }
 
+    @Transactional
     fun updateMilitaryDate(customUserDetails: CustomUserDetails, updateMilitaryDateRequest: UpdateMilitaryDateRequest) {
         val couple = coupleService.getByMemberId(customUserDetails.getId())
         anniversaryService.deleteAllByCoupleAndAutoInsert(couple)

--- a/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
@@ -96,6 +96,7 @@ class CoupleFacade(
 
     fun updateMilitaryDate(customUserDetails: CustomUserDetails, updateMilitaryDateRequest: UpdateMilitaryDateRequest) {
         val couple = coupleService.getByMemberId(customUserDetails.getId())
+        anniversaryService.deleteAllByCoupleIdAndAutoInsert(customUserDetails.getCouple())
         coupleInfoService.updateMilitaryDate(couple, updateMilitaryDateRequest)
     }
 

--- a/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
+++ b/src/main/kotlin/gomushin/backend/couple/facade/CoupleFacade.kt
@@ -96,7 +96,7 @@ class CoupleFacade(
 
     fun updateMilitaryDate(customUserDetails: CustomUserDetails, updateMilitaryDateRequest: UpdateMilitaryDateRequest) {
         val couple = coupleService.getByMemberId(customUserDetails.getId())
-        anniversaryService.deleteAllByCoupleIdAndAutoInsert(customUserDetails.getCouple())
+        anniversaryService.deleteAllByCoupleAndAutoInsert(couple)
         coupleInfoService.updateMilitaryDate(couple, updateMilitaryDateRequest)
     }
 

--- a/src/test/kotlin/gomushin/backend/couple/domain/service/AnniversaryServiceTest.kt
+++ b/src/test/kotlin/gomushin/backend/couple/domain/service/AnniversaryServiceTest.kt
@@ -192,7 +192,7 @@ class AnniversaryServiceTest {
             anniversaryRepository.deleteAllByCoupleIdAndAutoInsertTrue(couple.id)
         } just Runs
         //when
-        anniversaryService.deleteAllByCoupleIdAndAutoInsert(couple)
+        anniversaryService.deleteAllByCoupleAndAutoInsert(couple)
         //then
         verify(exactly = 1) {
             anniversaryRepository.deleteAllByCoupleIdAndAutoInsertTrue(couple.id)

--- a/src/test/kotlin/gomushin/backend/couple/domain/service/AnniversaryServiceTest.kt
+++ b/src/test/kotlin/gomushin/backend/couple/domain/service/AnniversaryServiceTest.kt
@@ -6,12 +6,10 @@ import gomushin.backend.couple.domain.repository.AnniversaryRepository
 import gomushin.backend.couple.dto.response.MonthlyAnniversariesResponse
 import gomushin.backend.schedule.dto.response.DailyAnniversaryResponse
 import gomushin.backend.schedule.dto.response.MainAnniversariesResponse
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import io.mockk.mockk
-import io.mockk.verify
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -183,6 +181,22 @@ class AnniversaryServiceTest {
             result.map { it.anniversaryDate },
             "반환된 기념일은 시간 순으로 정렬되어야 합니다."
         )
+    }
+
+    @DisplayName("deleteAllByCoupleIdAndAutoInsert는 anniversaryRepository의 deleteAllByCoupleIdAndAutoInsertTrue메서드 호출")
+    @Test
+    fun deleteAllByCoupleIdAndAutoInsert() {
+        //given
+        val couple = Couple(1L, 1L, 2L)
+        every {
+            anniversaryRepository.deleteAllByCoupleIdAndAutoInsertTrue(couple.id)
+        } just Runs
+        //when
+        anniversaryService.deleteAllByCoupleIdAndAutoInsert(couple)
+        //then
+        verify(exactly = 1) {
+            anniversaryRepository.deleteAllByCoupleIdAndAutoInsertTrue(couple.id)
+        }
     }
 }
 

--- a/src/test/kotlin/gomushin/backend/couple/facade/CoupleFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/couple/facade/CoupleFacadeTest.kt
@@ -165,7 +165,7 @@ class CoupleFacadeTest {
         )
         val result = coupleFacade.updateMilitaryDate(customUserDetails, updateMilitaryDateRequest)
         verify(coupleInfoService).updateMilitaryDate(customUserDetails.getCouple(), updateMilitaryDateRequest)
-        verify(anniversaryService).deleteAllByCoupleIdAndAutoInsert(customUserDetails.getCouple())
+        verify(anniversaryService).deleteAllByCoupleAndAutoInsert(customUserDetails.getCouple())
     }
 
     @DisplayName("만난날 수정 - 정상응답")

--- a/src/test/kotlin/gomushin/backend/couple/facade/CoupleFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/couple/facade/CoupleFacadeTest.kt
@@ -165,6 +165,7 @@ class CoupleFacadeTest {
         )
         val result = coupleFacade.updateMilitaryDate(customUserDetails, updateMilitaryDateRequest)
         verify(coupleInfoService).updateMilitaryDate(customUserDetails.getCouple(), updateMilitaryDateRequest)
+        verify(anniversaryService).deleteAllByCoupleIdAndAutoInsert(customUserDetails.getCouple())
     }
 
     @DisplayName("만난날 수정 - 정상응답")


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
#134 
- anniversary에 자동으로 계산되어서 삽입된 개체임을 알려주는 is_auto_insert컬럼 추
- 입대일, 전역일 수정 시 Dday초기설정한거 다시 재업데이트
- 기존 자동삽입된 기념일 삭제관련 테스트 코드 작성

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 자동으로 추가된 기념일을 구분할 수 있는 속성이 도입되었습니다.
  - 커플의 군 복무일 정보를 수정할 때, 자동으로 추가된 기념일이 함께 삭제됩니다.

- **테스트**
  - 자동 추가 기념일 삭제 기능과 군 복무일 수정 시 관련 동작이 정상적으로 수행되는지 확인하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->