### PR TITLE
Issue: (#156) 커플 연결 끊었을 경우, 상태메시지 제거 

### DIFF
--- a/src/main/kotlin/gomushin/backend/member/domain/entity/Member.kt
+++ b/src/main/kotlin/gomushin/backend/member/domain/entity/Member.kt
@@ -52,6 +52,8 @@ class Member(
 
     ) : BaseEntity() {
     companion object {
+        private const val EMPTY_STATUS_MESSAGE = ""
+        
         fun create(
             name: String,
             nickname: String?,
@@ -99,5 +101,9 @@ class Member(
 
     fun updateIsCouple(isCouple: Boolean) {
         this.isCouple = isCouple
+    }
+
+    fun clearStatusMessage() {
+        this.statusMessage = EMPTY_STATUS_MESSAGE
     }
 }

--- a/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
+++ b/src/main/kotlin/gomushin/backend/member/domain/service/MemberService.kt
@@ -53,4 +53,10 @@ class MemberService(
     fun getAllCoupledMemberWithEnabledNotification() : List<Member>{
         return memberRepository.findCoupleMembersWithEnabledNotification()
     }
+
+    @Transactional
+    fun clearMemberStatusMessage(id: Long) {
+        val member = getById(id)
+        member.clearStatusMessage()
+    }
 }

--- a/src/test/kotlin/gomushin/backend/member/facade/LeaveFacadeTest.kt
+++ b/src/test/kotlin/gomushin/backend/member/facade/LeaveFacadeTest.kt
@@ -1,0 +1,162 @@
+package gomushin.backend.member.facade
+
+import gomushin.backend.core.CustomUserDetails
+import gomushin.backend.core.event.dto.S3DeleteEvent
+import gomushin.backend.couple.domain.entity.Couple
+import gomushin.backend.couple.domain.service.AnniversaryService
+import gomushin.backend.couple.domain.service.CoupleInfoService
+import gomushin.backend.couple.domain.service.CoupleService
+import gomushin.backend.member.domain.entity.Member
+import gomushin.backend.member.domain.service.MemberService
+import gomushin.backend.member.domain.service.NotificationService
+import gomushin.backend.schedule.domain.entity.Picture
+import gomushin.backend.schedule.domain.service.CommentService
+import gomushin.backend.schedule.domain.service.LetterService
+import gomushin.backend.schedule.domain.service.PictureService
+import gomushin.backend.schedule.domain.service.ScheduleService
+import io.mockk.*
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.context.ApplicationEventPublisher
+
+@ExtendWith(MockKExtension::class)
+class LeaveFacadeTest {
+    @MockK
+    lateinit var anniversaryService: AnniversaryService
+    @MockK
+    lateinit var commentService: CommentService
+    @MockK
+    lateinit var coupleService: CoupleService
+    @MockK
+    lateinit var letterService: LetterService
+    @MockK
+    lateinit var memberService: MemberService
+    @MockK
+    lateinit var notificationService: NotificationService
+    @MockK
+    lateinit var pictureService: PictureService
+    @MockK
+    lateinit var scheduleService: ScheduleService
+    @MockK
+    lateinit var coupleInfoService: CoupleInfoService
+    @MockK
+    lateinit var applicationEventPublisher: ApplicationEventPublisher
+
+    @InjectMockKs
+    lateinit var leaveFacade: LeaveFacade
+
+    private val customUserDetails = mockk<CustomUserDetails>()
+    private val couple = mockk<Couple>()
+    private val partner = mockk<Member>()
+
+    @BeforeEach
+    fun setUp() {
+        every { customUserDetails.getId() } returns 1L
+        every { customUserDetails.getCouple() } returns couple
+        every { couple.id } returns 100L
+        every { partner.id } returns 2L
+        every { partner.updateIsCouple(false) } just Runs
+    }
+
+    @DisplayName("leave 메서드는 회원 탈퇴를 성공적으로 처리한다.")
+    @Test
+    fun leave_success() {
+        // given
+        val memberId = 1L
+        val partnerId = 2L
+        val coupleId = 100L
+        val memberLetterIds = listOf(10L, 11L)
+        val partnerLetterIds = listOf(20L, 21L)
+        val pictures = listOf(
+            mockk<Picture> { every { pictureUrl } returns "url1" },
+            mockk<Picture> { every { pictureUrl } returns "url2" }
+        )
+
+        every { coupleInfoService.findCoupleMember(memberId) } returns partner
+        every { anniversaryService.deleteAllByCoupleId(coupleId) } just Runs
+        every { commentService.deleteAllByMemberId(memberId) } just Runs
+        every { commentService.deleteAllByMemberId(partnerId) } just Runs
+        every { coupleService.deleteByMemberId(memberId) } just Runs
+        every { notificationService.deleteAllByMember(memberId) } just Runs
+        every { notificationService.deleteAllByMember(partnerId) } just Runs
+        every { scheduleService.deleteAllByMemberId(memberId) } just Runs
+        every { scheduleService.deleteAllByMemberId(partnerId) } just Runs
+        every { letterService.findAllByAuthorId(memberId) } returns memberLetterIds
+        every { letterService.findAllByAuthorId(partnerId) } returns partnerLetterIds
+        every { pictureService.findAllByLetterIds(memberLetterIds) } returns pictures
+        every { pictureService.findAllByLetterIds(partnerLetterIds) } returns emptyList()
+        every { pictureService.deleteAllByLetterIds(memberLetterIds) } just Runs
+        every { pictureService.deleteAllByLetterIds(partnerLetterIds) } just Runs
+        every { letterService.deleteAllByMemberId(memberId) } just Runs
+        every { letterService.deleteAllByMemberId(partnerId) } just Runs
+        every { memberService.clearMemberStatusMessage(memberId) } just Runs
+        every { memberService.clearMemberStatusMessage(partnerId) } just Runs
+        every { memberService.deleteMember(memberId) } just Runs
+        every { applicationEventPublisher.publishEvent(any<S3DeleteEvent>()) } just Runs
+
+        // when
+        leaveFacade.leave(customUserDetails)
+
+        // then
+        verify(exactly = 1) { coupleInfoService.findCoupleMember(memberId) }
+        verify(exactly = 1) { anniversaryService.deleteAllByCoupleId(coupleId) }
+        verify(exactly = 1) { commentService.deleteAllByMemberId(memberId) }
+        verify(exactly = 1) { commentService.deleteAllByMemberId(partnerId) }
+        verify(exactly = 1) { coupleService.deleteByMemberId(memberId) }
+        verify(exactly = 1) { notificationService.deleteAllByMember(memberId) }
+        verify(exactly = 1) { notificationService.deleteAllByMember(partnerId) }
+        verify(exactly = 1) { scheduleService.deleteAllByMemberId(memberId) }
+        verify(exactly = 1) { scheduleService.deleteAllByMemberId(partnerId) }
+        verify(exactly = 1) { letterService.findAllByAuthorId(memberId) }
+        verify(exactly = 1) { letterService.findAllByAuthorId(partnerId) }
+        verify(exactly = 1) { pictureService.findAllByLetterIds(memberLetterIds) }
+        verify(exactly = 1) { pictureService.findAllByLetterIds(partnerLetterIds) }
+        verify(exactly = 1) { pictureService.deleteAllByLetterIds(memberLetterIds) }
+        verify(exactly = 1) { pictureService.deleteAllByLetterIds(partnerLetterIds) }
+        verify(exactly = 1) { letterService.deleteAllByMemberId(memberId) }
+        verify(exactly = 1) { letterService.deleteAllByMemberId(partnerId) }
+        verify(exactly = 1) { memberService.clearMemberStatusMessage(memberId) }
+        verify(exactly = 1) { memberService.clearMemberStatusMessage(partnerId) }
+        verify(exactly = 1) { partner.updateIsCouple(false) }
+        verify(exactly = 1) { memberService.deleteMember(memberId) }
+        verify(exactly = 1) { applicationEventPublisher.publishEvent(any<S3DeleteEvent>()) }
+    }
+
+    @DisplayName("사진이 없는 경우 S3DeleteEvent가 발생하지 않는다.")
+    @Test
+    fun leave_success_without_pictures() {
+        // given
+        val memberId = 1L
+        val partnerId = 2L
+        val coupleId = 100L
+        val memberLetterIds = listOf(10L, 11L)
+        val partnerLetterIds = listOf(20L, 21L)
+
+        every { coupleInfoService.findCoupleMember(memberId) } returns partner
+        every { anniversaryService.deleteAllByCoupleId(coupleId) } just Runs
+        every { commentService.deleteAllByMemberId(any()) } just Runs
+        every { coupleService.deleteByMemberId(memberId) } just Runs
+        every { notificationService.deleteAllByMember(any()) } just Runs
+        every { scheduleService.deleteAllByMemberId(any()) } just Runs
+        every { letterService.findAllByAuthorId(memberId) } returns memberLetterIds
+        every { letterService.findAllByAuthorId(partnerId) } returns partnerLetterIds
+        every { pictureService.findAllByLetterIds(memberLetterIds) } returns emptyList()
+        every { pictureService.findAllByLetterIds(partnerLetterIds) } returns emptyList()
+        every { pictureService.deleteAllByLetterIds(any()) } just Runs
+        every { letterService.deleteAllByMemberId(any()) } just Runs
+        every { memberService.clearMemberStatusMessage(any()) } just Runs
+        every { memberService.deleteMember(memberId) } just Runs
+
+        // when
+        leaveFacade.leave(customUserDetails)
+
+        // then
+        verify(exactly = 0) { applicationEventPublisher.publishEvent(any<S3DeleteEvent>()) }
+        verify(exactly = 1) { memberService.deleteMember(memberId) }
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 탈퇴시 상태 메시지 제거를 위해 `Member` 엔티티와 `MemberService`에 코드 추가
- `LeaveFacade` 에 메시지 제거 로직 추가 및 `LeaveFacade`에 대한 테스트 코드 추가

---

## ✏️ 관련 이슈

- Resolves : #156  (무슨 이슈를 해결했는지)


---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원의 상태 메시지를 초기화하는 기능이 추가되었습니다.

* **리팩터**
  * 회원 탈퇴 처리 과정이 더 명확하게 분리된 내부 메서드들로 구성되어 관리가 용이해졌습니다.

* **테스트**
  * 회원 탈퇴 기능의 정상 동작을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->