### PR TITLE
Issue: (#163)  편지 사진 올리기 오류 수정

### DIFF
--- a/src/main/kotlin/gomushin/backend/core/infrastructure/filter/logging/LoggingFilter.kt
+++ b/src/main/kotlin/gomushin/backend/core/infrastructure/filter/logging/LoggingFilter.kt
@@ -18,6 +18,9 @@ class LoggingFilter : Filter {
 
     override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
         if (request is HttpServletRequest) {
+            if(request.contentType?.startsWith("multipart/") == true) {
+                chain.doFilter(request, response)
+            }
             val wrappedRequest = CachedBodyHttpServletRequest(request)
 
             val url = wrappedRequest.requestURI

--- a/src/main/kotlin/gomushin/backend/core/infrastructure/filter/logging/LoggingFilter.kt
+++ b/src/main/kotlin/gomushin/backend/core/infrastructure/filter/logging/LoggingFilter.kt
@@ -20,6 +20,7 @@ class LoggingFilter : Filter {
         if (request is HttpServletRequest) {
             if(request.contentType?.startsWith("multipart/") == true) {
                 chain.doFilter(request, response)
+                return
             }
             val wrappedRequest = CachedBodyHttpServletRequest(request)
 

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/UpsertAndDeleteLetterController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/UpsertAndDeleteLetterController.kt
@@ -2,12 +2,13 @@ package gomushin.backend.schedule.presentation
 
 import gomushin.backend.core.CustomUserDetails
 import gomushin.backend.core.common.web.response.ApiResponse
+import gomushin.backend.core.infrastructure.filter.logging.LoggingFilter
 import gomushin.backend.schedule.dto.request.UpsertLetterRequest
 import gomushin.backend.schedule.facade.UpsertAndDeleteLetterFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
@@ -17,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile
 class UpsertAndDeleteLetterController(
     private val upsertAndDeleteLetterFacade: UpsertAndDeleteLetterFacade,
 ) {
+    private val log = LoggerFactory.getLogger(UpsertAndDeleteLetterController::class.java)
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(
         ApiPath.LETTERS
@@ -24,9 +26,10 @@ class UpsertAndDeleteLetterController(
     @Operation(summary = "편지 수정하거나 추가하기", description = "upsertLetter")
     fun upsertLetter(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
-        @RequestPart("upsertLetterRequest") upsertLetterRequest: UpsertLetterRequest,
+        @RequestPart upsertLetterRequest: UpsertLetterRequest,
         @RequestPart("pictures", required = false) pictures: List<MultipartFile>?,
     ): ApiResponse<Boolean> {
+        log.info("[REQUEST LOG] userId={}, URL={}, Method={}, Body={}", customUserDetails.getId(), ApiPath.LETTERS, "POST", upsertLetterRequest)
         upsertAndDeleteLetterFacade.upsert(customUserDetails, upsertLetterRequest, pictures)
         return ApiResponse.success(true)
     }

--- a/src/main/kotlin/gomushin/backend/schedule/presentation/UpsertAndDeleteLetterController.kt
+++ b/src/main/kotlin/gomushin/backend/schedule/presentation/UpsertAndDeleteLetterController.kt
@@ -24,7 +24,7 @@ class UpsertAndDeleteLetterController(
     @Operation(summary = "편지 수정하거나 추가하기", description = "upsertLetter")
     fun upsertLetter(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
-        @RequestPart upsertLetterRequest: UpsertLetterRequest,
+        @RequestPart("upsertLetterRequest") upsertLetterRequest: UpsertLetterRequest,
         @RequestPart("pictures", required = false) pictures: List<MultipartFile>?,
     ): ApiResponse<Boolean> {
         upsertAndDeleteLetterFacade.upsert(customUserDetails, upsertLetterRequest, pictures)


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 편지 사진 올리기 오류 수정

---

## ✏️ 관련 이슈
#163 

## 🎸 기타 사항 or 추가 코멘트
편지가 업로드 시 MissingServeletRequestPartException이 일어난 이유
Controller요청 전에 LoggingFilter를 거쳐서 RequestPart부분을 읽어버림 -> controller에서 못 읽음
그래서 Multipart로 요청 시 LoggingFilter를 안 거치고 controller단에서 로그를 찍는 방식으로 변경함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * multipart 형식의 요청에 대해 로깅 필터가 정상적으로 동작하도록 개선되었습니다.

* **기능 개선**
  * 일정 관련 편지 등록/삭제 API 호출 시 요청 정보가 로그로 기록됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->